### PR TITLE
Create github action using builder-go to generate colorschemes

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,24 @@
+name: Update with the latest colorschemes
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # https://crontab.guru/every-week
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+      - name: Update schemes
+        uses: base16-project/base16-builder-go@latest
+      - name: Commit the changes, if any
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update with the latest colorschemes
+          branch: ${{ github.head_ref }}
+          commit_user_name: base16-project-bot
+          commit_user_email: base16themeproject@proton.me
+          commit_author: base16-project-bot <base16themeproject@proton.me>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+schemes

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
-[base16](https://github.com/base16-project/home) template for [foot](https://codeberg.org/dnkl/foot).
-[original repo](https://git.sr.ht/~h4n1/base16-foot).
+# base16-foot
 
-include in `foot.ini` like so:
+[base16][base16-home] template for [foot][foot-link].
 
-    include=~/.config/foot/colours.ini
+## Installation
 
-must be included under `[main]`, or the untitled section at the beginning of the file.
+Clone base16-foot to be able to reference the colorschemes.
+
+```shell
+git clone \
+  https://github.com/base16-project/base16-foot.git \
+  "$HOME/.config/base16-foot"
+```
+
+Include the following in your theme in your `foot.ini` (usually stored at
+`$HOME/.config/foot/foot.ini`) under `[main]`, or the untitled section
+at the beginning of the file.
+
+```ini
+include=~/.config/base16-foot/colors/base16-ayu-dark.ini
+```
+
+## Other
+
+[Original repo][sourcehut-foot-repo-link]
+
+[base16-home-link]: https://github.com/base16-project/home
+[foot-link]: https://codeberg.org/dnkl/foot
+[sourcehut-foot-repo-link]: https://git.sr.ht/~h4n1/base16-foot


### PR DESCRIPTION
- Update readme
- Add github action to build schemes with builder-go

I'm going to change the default branch to `main` along with this PR.