### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/foot
+* @tinted-theming/foot

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,12 +13,12 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Update with the latest colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright © 2022 h4n1
+Copyright (c) 2022 Tinted Theming
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clone base16-foot to be able to reference the colorschemes.
 
 ```shell
 git clone \
-  https://github.com/base16-project/base16-foot.git \
+  https://github.com/tinted-theming/base16-foot.git \
   "$HOME/.config/base16-foot"
 ```
 
@@ -24,6 +24,6 @@ include=~/.config/base16-foot/colors/base16-ayu-dark.ini
 
 [Original repo][sourcehut-foot-repo-link]
 
-[base16-home-link]: https://github.com/base16-project/home
+[base16-home-link]: https://github.com/tinted-theming/home
 [foot-link]: https://codeberg.org/dnkl/foot
 [sourcehut-foot-repo-link]: https://git.sr.ht/~h4n1/base16-foot

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,6 +1,7 @@
 # base16-foot
-# Base16 foot template by h4n1
-# {{scheme-name}} scheme by {{scheme-author}}
+# Scheme name: {{scheme-name}} 
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming)
 # include in foot.ini like so:
 # include=~/.config/foot/colours.ini
 # must be included under [main], or untitled section at beginning of file


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.