### PR TITLE
Add base24 theme template and rename repo to tinted-foot

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,10 @@
+name: "Auto assignment for issues"
+on:
+  issues:
+    types: ["opened"]
+
+jobs:
+  auto-assign:
+    uses: "tinted-theming/home/.github/workflows/shared-auto-assign-issues.yml@main"
+    secrets:
+      token: ${{ secrets.BOT_ACCESS_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,24 +1,13 @@
-name: Update with the latest colorschemes
+name: "Update with the latest tinted-theming colorschemes"
 on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0" # https://crontab.guru/every-week
 
 jobs:
-  run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch the repository code
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.BOT_ACCESS_TOKEN }}
-      - name: Update schemes
-        uses: tinted-theming/tinted-builder-rust@latest
-      - name: Commit the changes, if any
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Update with the latest colorschemes
-          branch: ${{ github.head_ref }}
-          commit_user_name: tinted-theming-bot
-          commit_user_email: tintedtheming@proton.me
-          commit_author: tinted-theming-bot <tintedtheming@proton.me>
+  build-and-commit:
+    uses: "tinted-theming/home/.github/workflows/shared-build-template-and-commit-themes.yml@main"
+    secrets:
+      token: ${{ secrets.BOT_ACCESS_TOKEN }}
+    with:
+      ref: ${{ github.head_ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-schemes

--- a/LICENCE
+++ b/LICENCE
@@ -1,10 +1,23 @@
 The MIT License (MIT)
 
-Copyright © 2022 h4n1
+Copyright (c) 2022 h4n1
 Copyright (c) 2022 Tinted Theming
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+“Software”), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-# base16-foot
+# Tinted Foot
 
-[base16][base16-home-link] template for [foot][foot-link].
+[Tinted Theming] template for [foot]. Includes both [base16] and
+[base24] themes.
 
 ## Installation
 
+### Manual
+
 Clone base16-foot to be able to reference the colorschemes.
 
-```shell
-git clone \
-  https://github.com/tinted-theming/base16-foot.git \
-  "$HOME/.config/base16-foot"
+```sh
+git clone https://github.com/tinted-theming/tinted-foot.git "$HOME/.config/tinted-theming/tinted-foot"
 ```
 
 Include the following in your theme in your `foot.ini` (usually stored at
@@ -17,13 +18,36 @@ Include the following in your theme in your `foot.ini` (usually stored at
 at the beginning of the file.
 
 ```ini
-include=~/.config/base16-foot/colors/base16-ayu-dark.ini
+include=~/.config/tinted-theming/tinted-foot/colors/base16-ayu-dark.ini
 ```
 
-## Other
+### Tinty
 
-[Original repo][sourcehut-foot-repo-link]
+If you use [Tinty] to apply your themes, complete the following steps to
+update your theme when running `tinty apply base16-ayu-dark` (where
+`base16-ayu-dark` is a placeholder scheme name):
 
-[base16-home-link]: https://github.com/tinted-theming/home
-[foot-link]: https://codeberg.org/dnkl/foot
-[sourcehut-foot-repo-link]: https://git.sr.ht/~h4n1/base16-foot
+1. Add the following `toml` settings to your Tinty
+   `~/.config/tinted-theming/tinty/config.toml` file:
+
+   ```toml
+   [[items]]
+   path = "https://github.com/tinted-theming/tinted-foot"
+   name = "tinted-foot"
+   themes-dir = "colors"
+   supported-systems = ["base16", "base24"]
+   ```
+
+2. Add the following include to `$HOME/.config/foot/foot.ini`:
+
+   ```ini
+   include=~/.local/share/tinted-theming/tinty/tinted-foot-colors-file.ini
+   ```
+
+3. `tinty apply base16-ayu-dark` will change your foot theme.
+
+For more information, have a look at the [Tinty] GitHub page.
+
+[Tinted Theming]: https://github.com/tinted-theming/home
+[foot]: https://codeberg.org/dnkl/foot
+[Tinty]: https://github.com/tinted-theming/tinty

--- a/colors/base16-3024.ini
+++ b/colors/base16-3024.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: 3024 
+# tinted-foot
+# Scheme name: 3024
 # Scheme author: Jan T. Sott (http://github.com/idleberg)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a5a2a2
 background=090300
@@ -16,7 +14,7 @@ regular4=01a0e4 # blue
 regular5=a16a94 # magenta
 regular6=b5e4f4 # cyan
 regular7=a5a2a2 # white
-bright0=5c5855 # bright black
+bright0=4a4543 # bright black
 bright1=db2d20 # bright red
 bright2=01a252 # bright green
 bright3=fded02 # bright yellow

--- a/colors/base16-apathy.ini
+++ b/colors/base16-apathy.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Apathy 
+# tinted-foot
+# Scheme name: Apathy
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=81b5ac
 background=031a16
@@ -16,7 +14,7 @@ regular4=96883e # blue
 regular5=4c963e # magenta
 regular6=963e4c # cyan
 regular7=81b5ac # white
-bright0=2b685e # bright black
+bright0=184e45 # bright black
 bright1=3e9688 # bright red
 bright2=883e96 # bright green
 bright3=3e4c96 # bright yellow

--- a/colors/base16-apprentice.ini
+++ b/colors/base16-apprentice.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Apprentice 
+# tinted-foot
+# Scheme name: Apprentice
 # Scheme author: romainl
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5f5f87
 background=262626
@@ -16,7 +14,7 @@ regular4=8787af # blue
 regular5=5fafaf # magenta
 regular6=87afd7 # cyan
 regular7=5f5f87 # white
-bright0=87875f # bright black
+bright0=5f875f # bright black
 bright1=444444 # bright red
 bright2=ffffaf # bright green
 bright3=87af87 # bright yellow

--- a/colors/base16-ashes.ini
+++ b/colors/base16-ashes.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Ashes 
+# tinted-foot
+# Scheme name: Ashes
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c7ccd1
 background=1c2023
@@ -16,7 +14,7 @@ regular4=ae95c7 # blue
 regular5=c795ae # magenta
 regular6=95aec7 # cyan
 regular7=c7ccd1 # white
-bright0=747c84 # bright black
+bright0=565e65 # bright black
 bright1=c7ae95 # bright red
 bright2=95c7ae # bright green
 bright3=aec795 # bright yellow

--- a/colors/base16-atelier-cave-light.ini
+++ b/colors/base16-atelier-cave-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Cave Light 
+# tinted-foot
+# Scheme name: Atelier Cave Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=585260
 background=efecf4
@@ -16,7 +14,7 @@ regular4=576ddb # blue
 regular5=955ae7 # magenta
 regular6=398bc6 # cyan
 regular7=585260 # white
-bright0=7e7887 # bright black
+bright0=8b8792 # bright black
 bright1=be4678 # bright red
 bright2=2a9292 # bright green
 bright3=a06e3b # bright yellow

--- a/colors/base16-atelier-cave.ini
+++ b/colors/base16-atelier-cave.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Cave 
+# tinted-foot
+# Scheme name: Atelier Cave
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=8b8792
 background=19171c
@@ -16,7 +14,7 @@ regular4=576ddb # blue
 regular5=955ae7 # magenta
 regular6=398bc6 # cyan
 regular7=8b8792 # white
-bright0=655f6d # bright black
+bright0=585260 # bright black
 bright1=be4678 # bright red
 bright2=2a9292 # bright green
 bright3=a06e3b # bright yellow

--- a/colors/base16-atelier-dune-light.ini
+++ b/colors/base16-atelier-dune-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Dune Light 
+# tinted-foot
+# Scheme name: Atelier Dune Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=6e6b5e
 background=fefbec
@@ -16,7 +14,7 @@ regular4=6684e1 # blue
 regular5=b854d4 # magenta
 regular6=1fad83 # cyan
 regular7=6e6b5e # white
-bright0=999580 # bright black
+bright0=a6a28c # bright black
 bright1=d73737 # bright red
 bright2=60ac39 # bright green
 bright3=ae9513 # bright yellow

--- a/colors/base16-atelier-dune.ini
+++ b/colors/base16-atelier-dune.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Dune 
+# tinted-foot
+# Scheme name: Atelier Dune
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a6a28c
 background=20201d
@@ -16,7 +14,7 @@ regular4=6684e1 # blue
 regular5=b854d4 # magenta
 regular6=1fad83 # cyan
 regular7=a6a28c # white
-bright0=7d7a68 # bright black
+bright0=6e6b5e # bright black
 bright1=d73737 # bright red
 bright2=60ac39 # bright green
 bright3=ae9513 # bright yellow

--- a/colors/base16-atelier-estuary-light.ini
+++ b/colors/base16-atelier-estuary-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Estuary Light 
+# tinted-foot
+# Scheme name: Atelier Estuary Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5f5e4e
 background=f4f3ec
@@ -16,7 +14,7 @@ regular4=36a166 # blue
 regular5=5f9182 # magenta
 regular6=5b9d48 # cyan
 regular7=5f5e4e # white
-bright0=878573 # bright black
+bright0=929181 # bright black
 bright1=ba6236 # bright red
 bright2=7d9726 # bright green
 bright3=a5980d # bright yellow

--- a/colors/base16-atelier-estuary.ini
+++ b/colors/base16-atelier-estuary.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Estuary 
+# tinted-foot
+# Scheme name: Atelier Estuary
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=929181
 background=22221b
@@ -16,7 +14,7 @@ regular4=36a166 # blue
 regular5=5f9182 # magenta
 regular6=5b9d48 # cyan
 regular7=929181 # white
-bright0=6c6b5a # bright black
+bright0=5f5e4e # bright black
 bright1=ba6236 # bright red
 bright2=7d9726 # bright green
 bright3=a5980d # bright yellow

--- a/colors/base16-atelier-forest-light.ini
+++ b/colors/base16-atelier-forest-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Forest Light 
+# tinted-foot
+# Scheme name: Atelier Forest Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=68615e
 background=f1efee
@@ -16,7 +14,7 @@ regular4=407ee7 # blue
 regular5=6666ea # magenta
 regular6=3d97b8 # cyan
 regular7=68615e # white
-bright0=9c9491 # bright black
+bright0=a8a19f # bright black
 bright1=f22c40 # bright red
 bright2=7b9726 # bright green
 bright3=c38418 # bright yellow

--- a/colors/base16-atelier-forest.ini
+++ b/colors/base16-atelier-forest.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Forest 
+# tinted-foot
+# Scheme name: Atelier Forest
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a8a19f
 background=1b1918
@@ -16,7 +14,7 @@ regular4=407ee7 # blue
 regular5=6666ea # magenta
 regular6=3d97b8 # cyan
 regular7=a8a19f # white
-bright0=766e6b # bright black
+bright0=68615e # bright black
 bright1=f22c40 # bright red
 bright2=7b9726 # bright green
 bright3=c38418 # bright yellow

--- a/colors/base16-atelier-heath-light.ini
+++ b/colors/base16-atelier-heath-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Heath Light 
+# tinted-foot
+# Scheme name: Atelier Heath Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=695d69
 background=f7f3f7
@@ -16,7 +14,7 @@ regular4=516aec # blue
 regular5=7b59c0 # magenta
 regular6=159393 # cyan
 regular7=695d69 # white
-bright0=9e8f9e # bright black
+bright0=ab9bab # bright black
 bright1=ca402b # bright red
 bright2=918b3b # bright green
 bright3=bb8a35 # bright yellow

--- a/colors/base16-atelier-heath.ini
+++ b/colors/base16-atelier-heath.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Heath 
+# tinted-foot
+# Scheme name: Atelier Heath
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ab9bab
 background=1b181b
@@ -16,7 +14,7 @@ regular4=516aec # blue
 regular5=7b59c0 # magenta
 regular6=159393 # cyan
 regular7=ab9bab # white
-bright0=776977 # bright black
+bright0=695d69 # bright black
 bright1=ca402b # bright red
 bright2=918b3b # bright green
 bright3=bb8a35 # bright yellow

--- a/colors/base16-atelier-lakeside-light.ini
+++ b/colors/base16-atelier-lakeside-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Lakeside Light 
+# tinted-foot
+# Scheme name: Atelier Lakeside Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=516d7b
 background=ebf8ff
@@ -16,7 +14,7 @@ regular4=257fad # blue
 regular5=6b6bb8 # magenta
 regular6=2d8f6f # cyan
 regular7=516d7b # white
-bright0=7195a8 # bright black
+bright0=7ea2b4 # bright black
 bright1=d22d72 # bright red
 bright2=568c3b # bright green
 bright3=8a8a0f # bright yellow

--- a/colors/base16-atelier-lakeside.ini
+++ b/colors/base16-atelier-lakeside.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Lakeside 
+# tinted-foot
+# Scheme name: Atelier Lakeside
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=7ea2b4
 background=161b1d
@@ -16,7 +14,7 @@ regular4=257fad # blue
 regular5=6b6bb8 # magenta
 regular6=2d8f6f # cyan
 regular7=7ea2b4 # white
-bright0=5a7b8c # bright black
+bright0=516d7b # bright black
 bright1=d22d72 # bright red
 bright2=568c3b # bright green
 bright3=8a8a0f # bright yellow

--- a/colors/base16-atelier-plateau-light.ini
+++ b/colors/base16-atelier-plateau-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Plateau Light 
+# tinted-foot
+# Scheme name: Atelier Plateau Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=585050
 background=f4ecec
@@ -16,7 +14,7 @@ regular4=7272ca # blue
 regular5=8464c4 # magenta
 regular6=5485b6 # cyan
 regular7=585050 # white
-bright0=7e7777 # bright black
+bright0=8a8585 # bright black
 bright1=ca4949 # bright red
 bright2=4b8b8b # bright green
 bright3=a06e3b # bright yellow

--- a/colors/base16-atelier-plateau.ini
+++ b/colors/base16-atelier-plateau.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Plateau 
+# tinted-foot
+# Scheme name: Atelier Plateau
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=8a8585
 background=1b1818
@@ -16,7 +14,7 @@ regular4=7272ca # blue
 regular5=8464c4 # magenta
 regular6=5485b6 # cyan
 regular7=8a8585 # white
-bright0=655d5d # bright black
+bright0=585050 # bright black
 bright1=ca4949 # bright red
 bright2=4b8b8b # bright green
 bright3=a06e3b # bright yellow

--- a/colors/base16-atelier-savanna-light.ini
+++ b/colors/base16-atelier-savanna-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Savanna Light 
+# tinted-foot
+# Scheme name: Atelier Savanna Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=526057
 background=ecf4ee
@@ -16,7 +14,7 @@ regular4=478c90 # blue
 regular5=55859b # magenta
 regular6=1c9aa0 # cyan
 regular7=526057 # white
-bright0=78877d # bright black
+bright0=87928a # bright black
 bright1=b16139 # bright red
 bright2=489963 # bright green
 bright3=a07e3b # bright yellow

--- a/colors/base16-atelier-savanna.ini
+++ b/colors/base16-atelier-savanna.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Savanna 
+# tinted-foot
+# Scheme name: Atelier Savanna
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=87928a
 background=171c19
@@ -16,7 +14,7 @@ regular4=478c90 # blue
 regular5=55859b # magenta
 regular6=1c9aa0 # cyan
 regular7=87928a # white
-bright0=5f6d64 # bright black
+bright0=526057 # bright black
 bright1=b16139 # bright red
 bright2=489963 # bright green
 bright3=a07e3b # bright yellow

--- a/colors/base16-atelier-seaside-light.ini
+++ b/colors/base16-atelier-seaside-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Seaside Light 
+# tinted-foot
+# Scheme name: Atelier Seaside Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5e6e5e
 background=f4fbf4
@@ -16,7 +14,7 @@ regular4=3d62f5 # blue
 regular5=ad2bee # magenta
 regular6=1999b3 # cyan
 regular7=5e6e5e # white
-bright0=809980 # bright black
+bright0=8ca68c # bright black
 bright1=e6193c # bright red
 bright2=29a329 # bright green
 bright3=98981b # bright yellow

--- a/colors/base16-atelier-seaside.ini
+++ b/colors/base16-atelier-seaside.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Seaside 
+# tinted-foot
+# Scheme name: Atelier Seaside
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=8ca68c
 background=131513
@@ -16,7 +14,7 @@ regular4=3d62f5 # blue
 regular5=ad2bee # magenta
 regular6=1999b3 # cyan
 regular7=8ca68c # white
-bright0=687d68 # bright black
+bright0=5e6e5e # bright black
 bright1=e6193c # bright red
 bright2=29a329 # bright green
 bright3=98981b # bright yellow

--- a/colors/base16-atelier-sulphurpool-light.ini
+++ b/colors/base16-atelier-sulphurpool-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Sulphurpool Light 
+# tinted-foot
+# Scheme name: Atelier Sulphurpool Light
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5e6687
 background=f5f7ff
@@ -16,7 +14,7 @@ regular4=3d8fd1 # blue
 regular5=6679cc # magenta
 regular6=22a2c9 # cyan
 regular7=5e6687 # white
-bright0=898ea4 # bright black
+bright0=979db4 # bright black
 bright1=c94922 # bright red
 bright2=ac9739 # bright green
 bright3=c08b30 # bright yellow

--- a/colors/base16-atelier-sulphurpool.ini
+++ b/colors/base16-atelier-sulphurpool.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atelier Sulphurpool 
+# tinted-foot
+# Scheme name: Atelier Sulphurpool
 # Scheme author: Bram de Haan (http://atelierbramdehaan.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=979db4
 background=202746
@@ -16,7 +14,7 @@ regular4=3d8fd1 # blue
 regular5=6679cc # magenta
 regular6=22a2c9 # cyan
 regular7=979db4 # white
-bright0=6b7394 # bright black
+bright0=5e6687 # bright black
 bright1=c94922 # bright red
 bright2=ac9739 # bright green
 bright3=c08b30 # bright yellow

--- a/colors/base16-atlas.ini
+++ b/colors/base16-atlas.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Atlas 
+# tinted-foot
+# Scheme name: Atlas
 # Scheme author: Alex Lende (https://ajlende.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a1a19a
 background=002635
@@ -16,7 +14,7 @@ regular4=14747e # blue
 regular5=9a70a4 # magenta
 regular6=5dd7b9 # cyan
 regular7=a1a19a # white
-bright0=6c8b91 # bright black
+bright0=517f8d # bright black
 bright1=ff5a67 # bright red
 bright2=7fc06e # bright green
 bright3=ffcc1b # bright yellow

--- a/colors/base16-ayu-dark.ini
+++ b/colors/base16-ayu-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Ayu Dark 
+# tinted-foot
+# Scheme name: Ayu Dark
 # Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e6e1cf
 background=0f1419
@@ -16,7 +14,7 @@ regular4=59c2ff # blue
 regular5=d2a6ff # magenta
 regular6=95e6cb # cyan
 regular7=e6e1cf # white
-bright0=3e4b59 # bright black
+bright0=272d38 # bright black
 bright1=f07178 # bright red
 bright2=b8cc52 # bright green
 bright3=ffb454 # bright yellow

--- a/colors/base16-ayu-light.ini
+++ b/colors/base16-ayu-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Ayu Light 
+# tinted-foot
+# Scheme name: Ayu Light
 # Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5c6773
 background=fafafa
@@ -16,7 +14,7 @@ regular4=36a3d9 # blue
 regular5=a37acc # magenta
 regular6=4cbf99 # cyan
 regular7=5c6773 # white
-bright0=abb0b6 # bright black
+bright0=f8f9fa # bright black
 bright1=f07178 # bright red
 bright2=86b300 # bright green
 bright3=f2ae49 # bright yellow

--- a/colors/base16-ayu-mirage.ini
+++ b/colors/base16-ayu-mirage.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Ayu Mirage 
+# tinted-foot
+# Scheme name: Ayu Mirage
 # Scheme author: Khue Nguyen &lt;Z5483Y@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cccac2
 background=171b24
@@ -16,7 +14,7 @@ regular4=5ccfe6 # blue
 regular5=d4bfff # magenta
 regular6=95e6cb # cyan
 regular7=cccac2 # white
-bright0=707a8c # bright black
+bright0=242936 # bright black
 bright1=f28779 # bright red
 bright2=d5ff80 # bright green
 bright3=ffd173 # bright yellow

--- a/colors/base16-aztec.ini
+++ b/colors/base16-aztec.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Aztec 
+# tinted-foot
+# Scheme name: Aztec
 # Scheme author: TheNeverMan (github.com/TheNeverMan)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ffda51
 background=101600
@@ -16,7 +14,7 @@ regular4=5b4a9f # blue
 regular5=883e9f # magenta
 regular6=3d94a5 # cyan
 regular7=ffda51 # white
-bright0=2e2e05 # bright black
+bright0=242604 # bright black
 bright1=ee2e00 # bright red
 bright2=63d932 # bright green
 bright3=eebb00 # bright yellow

--- a/colors/base16-bespin.ini
+++ b/colors/base16-bespin.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Bespin 
+# tinted-foot
+# Scheme name: Bespin
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=8a8986
 background=28211c
@@ -16,7 +14,7 @@ regular4=5ea6ea # blue
 regular5=9b859d # magenta
 regular6=afc4db # cyan
 regular7=8a8986 # white
-bright0=666666 # bright black
+bright0=5e5d5c # bright black
 bright1=cf6a4c # bright red
 bright2=54be0d # bright green
 bright3=f9ee98 # bright yellow

--- a/colors/base16-black-metal-bathory.ini
+++ b/colors/base16-black-metal-bathory.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Bathory) 
+# tinted-foot
+# Scheme name: Black Metal (Bathory)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=fbcb97 # bright green
 bright3=e78a53 # bright yellow

--- a/colors/base16-black-metal-burzum.ini
+++ b/colors/base16-black-metal-burzum.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Burzum) 
+# tinted-foot
+# Scheme name: Black Metal (Burzum)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=ddeecc # bright green
 bright3=99bbaa # bright yellow

--- a/colors/base16-black-metal-dark-funeral.ini
+++ b/colors/base16-black-metal-dark-funeral.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Dark Funeral) 
+# tinted-foot
+# Scheme name: Black Metal (Dark Funeral)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=d0dfee # bright green
 bright3=5f81a5 # bright yellow

--- a/colors/base16-black-metal-gorgoroth.ini
+++ b/colors/base16-black-metal-gorgoroth.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Gorgoroth) 
+# tinted-foot
+# Scheme name: Black Metal (Gorgoroth)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=9b8d7f # bright green
 bright3=8c7f70 # bright yellow

--- a/colors/base16-black-metal-immortal.ini
+++ b/colors/base16-black-metal-immortal.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Immortal) 
+# tinted-foot
+# Scheme name: Black Metal (Immortal)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=7799bb # bright green
 bright3=556677 # bright yellow

--- a/colors/base16-black-metal-khold.ini
+++ b/colors/base16-black-metal-khold.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Khold) 
+# tinted-foot
+# Scheme name: Black Metal (Khold)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=eceee3 # bright green
 bright3=974b46 # bright yellow

--- a/colors/base16-black-metal-marduk.ini
+++ b/colors/base16-black-metal-marduk.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Marduk) 
+# tinted-foot
+# Scheme name: Black Metal (Marduk)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=a5aaa7 # bright green
 bright3=626b67 # bright yellow

--- a/colors/base16-black-metal-mayhem.ini
+++ b/colors/base16-black-metal-mayhem.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Mayhem) 
+# tinted-foot
+# Scheme name: Black Metal (Mayhem)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=f3ecd4 # bright green
 bright3=eecc6c # bright yellow

--- a/colors/base16-black-metal-nile.ini
+++ b/colors/base16-black-metal-nile.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Nile) 
+# tinted-foot
+# Scheme name: Black Metal (Nile)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=aa9988 # bright green
 bright3=777755 # bright yellow

--- a/colors/base16-black-metal-venom.ini
+++ b/colors/base16-black-metal-venom.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal (Venom) 
+# tinted-foot
+# Scheme name: Black Metal (Venom)
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=f8f7f2 # bright green
 bright3=79241f # bright yellow

--- a/colors/base16-black-metal.ini
+++ b/colors/base16-black-metal.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Black Metal 
+# tinted-foot
+# Scheme name: Black Metal
 # Scheme author: metalelf0 (https://github.com/metalelf0)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c1c1
 background=000000
@@ -16,7 +14,7 @@ regular4=888888 # blue
 regular5=999999 # magenta
 regular6=aaaaaa # cyan
 regular7=c1c1c1 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=5f8787 # bright red
 bright2=dd9999 # bright green
 bright3=a06666 # bright yellow

--- a/colors/base16-blueforest.ini
+++ b/colors/base16-blueforest.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Blue Forest 
+# tinted-foot
+# Scheme name: Blue Forest
 # Scheme author: alonsodomin (https://github.com/alonsodomin)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ffcc33
 background=141f2e
@@ -16,7 +14,7 @@ regular4=a2cff5 # blue
 regular5=0099ff # magenta
 regular6=80ff80 # cyan
 regular7=ffcc33 # white
-bright0=a0ffa0 # bright black
+bright0=273e5c # bright black
 bright1=fffab1 # bright red
 bright2=80ff80 # bright green
 bright3=91ccff # bright yellow

--- a/colors/base16-blueish.ini
+++ b/colors/base16-blueish.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Blueish 
+# tinted-foot
+# Scheme name: Blueish
 # Scheme author: Ben Mayoras
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c8e1f8
 background=182430
@@ -16,7 +14,7 @@ regular4=82aaff # blue
 regular5=ff84dd # magenta
 regular6=5fd1ff # cyan
 regular7=c8e1f8 # white
-bright0=616d78 # bright black
+bright0=46290a # bright black
 bright1=4ce587 # bright red
 bright2=c3e88d # bright green
 bright3=82aaff # bright yellow

--- a/colors/base16-brewer.ini
+++ b/colors/base16-brewer.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Brewer 
+# tinted-foot
+# Scheme name: Brewer
 # Scheme author: Timothée Poisot (http://github.com/tpoisot)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b7b8b9
 background=0c0d0e
@@ -16,7 +14,7 @@ regular4=3182bd # blue
 regular5=756bb1 # magenta
 regular6=80b1d3 # cyan
 regular7=b7b8b9 # white
-bright0=737475 # bright black
+bright0=515253 # bright black
 bright1=e31a1c # bright red
 bright2=31a354 # bright green
 bright3=dca060 # bright yellow

--- a/colors/base16-bright.ini
+++ b/colors/base16-bright.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Bright 
+# tinted-foot
+# Scheme name: Bright
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e0e0e0
 background=000000
@@ -16,7 +14,7 @@ regular4=6fb3d2 # blue
 regular5=d381c3 # magenta
 regular6=76c7b7 # cyan
 regular7=e0e0e0 # white
-bright0=b0b0b0 # bright black
+bright0=505050 # bright black
 bright1=fb0120 # bright red
 bright2=a1c659 # bright green
 bright3=fda331 # bright yellow

--- a/colors/base16-brogrammer.ini
+++ b/colors/base16-brogrammer.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Brogrammer 
+# tinted-foot
+# Scheme name: Brogrammer
 # Scheme author: Vik Ramanujam (http://github.com/piggyslasher)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=4e5ab7
 background=1f1f1f
@@ -16,7 +14,7 @@ regular4=5350b9 # blue
 regular5=0f7ddb # magenta
 regular6=1081d6 # cyan
 regular7=4e5ab7 # white
-bright0=ecba0f # bright black
+bright0=2dc55e # bright black
 bright1=d6dbe5 # bright red
 bright2=f3bd09 # bright green
 bright3=1dd361 # bright yellow

--- a/colors/base16-brushtrees-dark.ini
+++ b/colors/base16-brushtrees-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Brush Trees Dark 
+# tinted-foot
+# Scheme name: Brush Trees Dark
 # Scheme author: Abraham White &lt;abelincoln.white@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b0c5c8
 background=485867
@@ -16,7 +14,7 @@ regular4=868cb3 # blue
 regular5=b386b2 # magenta
 regular6=86b3b3 # cyan
 regular7=b0c5c8 # white
-bright0=8299a1 # bright black
+bright0=6d828e # bright black
 bright1=b38686 # bright red
 bright2=87b386 # bright green
 bright3=aab386 # bright yellow

--- a/colors/base16-brushtrees.ini
+++ b/colors/base16-brushtrees.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Brush Trees 
+# tinted-foot
+# Scheme name: Brush Trees
 # Scheme author: Abraham White &lt;abelincoln.white@gmail.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=6d828e
 background=e3efef
@@ -16,7 +14,7 @@ regular4=868cb3 # blue
 regular5=b386b2 # magenta
 regular6=86b3b3 # cyan
 regular7=6d828e # white
-bright0=98afb5 # bright black
+bright0=b0c5c8 # bright black
 bright1=b38686 # bright red
 bright2=87b386 # bright green
 bright3=aab386 # bright yellow

--- a/colors/base16-caroline.ini
+++ b/colors/base16-caroline.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: caroline 
+# tinted-foot
+# Scheme name: caroline
 # Scheme author: ed (https://codeberg.org/ed)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a87569
 background=1c1213
@@ -16,7 +14,7 @@ regular4=684c59 # blue
 regular5=a63650 # magenta
 regular6=6b6566 # cyan
 regular7=a87569 # white
-bright0=6d4745 # bright black
+bright0=563837 # bright black
 bright1=c24f57 # bright red
 bright2=806c61 # bright green
 bright3=f28171 # bright yellow

--- a/colors/base16-catppuccin-frappe.ini
+++ b/colors/base16-catppuccin-frappe.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Catppuccin Frappe 
+# tinted-foot
+# Scheme name: Catppuccin Frappe
 # Scheme author: https://github.com/catppuccin/catppuccin
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c6d0f5
 background=303446
@@ -16,7 +14,7 @@ regular4=8caaee # blue
 regular5=ca9ee6 # magenta
 regular6=81c8be # cyan
 regular7=c6d0f5 # white
-bright0=51576d # bright black
+bright0=414559 # bright black
 bright1=e78284 # bright red
 bright2=a6d189 # bright green
 bright3=e5c890 # bright yellow

--- a/colors/base16-catppuccin-latte.ini
+++ b/colors/base16-catppuccin-latte.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Catppuccin Latte 
+# tinted-foot
+# Scheme name: Catppuccin Latte
 # Scheme author: https://github.com/catppuccin/catppuccin
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=4c4f69
 background=eff1f5
@@ -16,7 +14,7 @@ regular4=1e66f5 # blue
 regular5=8839ef # magenta
 regular6=179299 # cyan
 regular7=4c4f69 # white
-bright0=bcc0cc # bright black
+bright0=ccd0da # bright black
 bright1=d20f39 # bright red
 bright2=40a02b # bright green
 bright3=df8e1d # bright yellow

--- a/colors/base16-catppuccin-macchiato.ini
+++ b/colors/base16-catppuccin-macchiato.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Catppuccin Macchiato 
+# tinted-foot
+# Scheme name: Catppuccin Macchiato
 # Scheme author: https://github.com/catppuccin/catppuccin
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cad3f5
 background=24273a
@@ -16,7 +14,7 @@ regular4=8aadf4 # blue
 regular5=c6a0f6 # magenta
 regular6=8bd5ca # cyan
 regular7=cad3f5 # white
-bright0=494d64 # bright black
+bright0=363a4f # bright black
 bright1=ed8796 # bright red
 bright2=a6da95 # bright green
 bright3=eed49f # bright yellow

--- a/colors/base16-catppuccin-mocha.ini
+++ b/colors/base16-catppuccin-mocha.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Catppuccin Mocha 
+# tinted-foot
+# Scheme name: Catppuccin Mocha
 # Scheme author: https://github.com/catppuccin/catppuccin
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cdd6f4
 background=1e1e2e
@@ -16,7 +14,7 @@ regular4=89b4fa # blue
 regular5=cba6f7 # magenta
 regular6=94e2d5 # cyan
 regular7=cdd6f4 # white
-bright0=45475a # bright black
+bright0=313244 # bright black
 bright1=f38ba8 # bright red
 bright2=a6e3a1 # bright green
 bright3=f9e2af # bright yellow

--- a/colors/base16-chalk.ini
+++ b/colors/base16-chalk.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Chalk 
+# tinted-foot
+# Scheme name: Chalk
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d0d0d0
 background=151515
@@ -16,7 +14,7 @@ regular4=6fc2ef # blue
 regular5=e1a3ee # magenta
 regular6=12cfc0 # cyan
 regular7=d0d0d0 # white
-bright0=505050 # bright black
+bright0=303030 # bright black
 bright1=fb9fb1 # bright red
 bright2=acc267 # bright green
 bright3=ddb26f # bright yellow

--- a/colors/base16-circus.ini
+++ b/colors/base16-circus.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Circus 
+# tinted-foot
+# Scheme name: Circus
 # Scheme author: Stephan Boyer (https://github.com/stepchowfun) and Esther Wang (https://github.com/ewang12)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a7a7a7
 background=191919
@@ -16,7 +14,7 @@ regular4=639ee4 # blue
 regular5=b888e2 # magenta
 regular6=4bb1a7 # cyan
 regular7=a7a7a7 # white
-bright0=5f5a60 # bright black
+bright0=303030 # bright black
 bright1=dc657d # bright red
 bright2=84b97c # bright green
 bright3=c3ba63 # bright yellow

--- a/colors/base16-classic-dark.ini
+++ b/colors/base16-classic-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Classic Dark 
+# tinted-foot
+# Scheme name: Classic Dark
 # Scheme author: Jason Heeris (http://heeris.id.au)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d0d0d0
 background=151515
@@ -16,7 +14,7 @@ regular4=6a9fb5 # blue
 regular5=aa759f # magenta
 regular6=75b5aa # cyan
 regular7=d0d0d0 # white
-bright0=505050 # bright black
+bright0=303030 # bright black
 bright1=ac4142 # bright red
 bright2=90a959 # bright green
 bright3=f4bf75 # bright yellow

--- a/colors/base16-classic-light.ini
+++ b/colors/base16-classic-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Classic Light 
+# tinted-foot
+# Scheme name: Classic Light
 # Scheme author: Jason Heeris (http://heeris.id.au)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=303030
 background=f5f5f5
@@ -16,7 +14,7 @@ regular4=6a9fb5 # blue
 regular5=aa759f # magenta
 regular6=75b5aa # cyan
 regular7=303030 # white
-bright0=b0b0b0 # bright black
+bright0=d0d0d0 # bright black
 bright1=ac4142 # bright red
 bright2=90a959 # bright green
 bright3=f4bf75 # bright yellow

--- a/colors/base16-codeschool.ini
+++ b/colors/base16-codeschool.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Codeschool 
+# tinted-foot
+# Scheme name: Codeschool
 # Scheme author: blockloop
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=9ea7a6
 background=232c31
@@ -16,7 +14,7 @@ regular4=484d79 # blue
 regular5=c59820 # magenta
 regular6=b02f30 # cyan
 regular7=9ea7a6 # white
-bright0=3f4944 # bright black
+bright0=2a343a # bright black
 bright1=2a5491 # bright red
 bright2=237986 # bright green
 bright3=a03b1e # bright yellow

--- a/colors/base16-colors.ini
+++ b/colors/base16-colors.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Colors 
+# tinted-foot
+# Scheme name: Colors
 # Scheme author: mrmrs (http://clrs.cc)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=bbbbbb
 background=111111
@@ -16,7 +14,7 @@ regular4=0074d9 # blue
 regular5=b10dc9 # magenta
 regular6=7fdbff # cyan
 regular7=bbbbbb # white
-bright0=777777 # bright black
+bright0=555555 # bright black
 bright1=ff4136 # bright red
 bright2=2ecc40 # bright green
 bright3=ffdc00 # bright yellow

--- a/colors/base16-cupcake.ini
+++ b/colors/base16-cupcake.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Cupcake 
+# tinted-foot
+# Scheme name: Cupcake
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=8b8198
 background=fbf1f2
@@ -16,7 +14,7 @@ regular4=7297b9 # blue
 regular5=bb99b4 # magenta
 regular6=69a9a7 # cyan
 regular7=8b8198 # white
-bright0=bfb9c6 # bright black
+bright0=d8d5dd # bright black
 bright1=d57e85 # bright red
 bright2=a3b367 # bright green
 bright3=dcb16c # bright yellow

--- a/colors/base16-cupertino.ini
+++ b/colors/base16-cupertino.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Cupertino 
+# tinted-foot
+# Scheme name: Cupertino
 # Scheme author: Defman21
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=404040
 background=ffffff
@@ -16,7 +14,7 @@ regular4=0000ff # blue
 regular5=a90d91 # magenta
 regular6=318495 # cyan
 regular7=404040 # white
-bright0=808080 # bright black
+bright0=c0c0c0 # bright black
 bright1=c41a15 # bright red
 bright2=007400 # bright green
 bright3=826b28 # bright yellow

--- a/colors/base16-da-one-black.ini
+++ b/colors/base16-da-one-black.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Da One Black 
+# tinted-foot
+# Scheme name: Da One Black
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ffffff
 background=000000
@@ -16,7 +14,7 @@ regular4=6bb8ff # blue
 regular5=e799ff # magenta
 regular6=8af5ff # cyan
 regular7=ffffff # white
-bright0=888888 # bright black
+bright0=585858 # bright black
 bright1=fa7883 # bright red
 bright2=98c379 # bright green
 bright3=ff9470 # bright yellow

--- a/colors/base16-da-one-gray.ini
+++ b/colors/base16-da-one-gray.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Da One Gray 
+# tinted-foot
+# Scheme name: Da One Gray
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ffffff
 background=181818
@@ -16,7 +14,7 @@ regular4=6bb8ff # blue
 regular5=e799ff # magenta
 regular6=8af5ff # cyan
 regular7=ffffff # white
-bright0=888888 # bright black
+bright0=585858 # bright black
 bright1=fa7883 # bright red
 bright2=98c379 # bright green
 bright3=ff9470 # bright yellow

--- a/colors/base16-da-one-ocean.ini
+++ b/colors/base16-da-one-ocean.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Da One Ocean 
+# tinted-foot
+# Scheme name: Da One Ocean
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ffffff
 background=171726
@@ -16,7 +14,7 @@ regular4=6bb8ff # blue
 regular5=e799ff # magenta
 regular6=8af5ff # cyan
 regular7=ffffff # white
-bright0=878d96 # bright black
+bright0=525866 # bright black
 bright1=fa7883 # bright red
 bright2=98c379 # bright green
 bright3=ff9470 # bright yellow

--- a/colors/base16-da-one-paper.ini
+++ b/colors/base16-da-one-paper.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Da One Paper 
+# tinted-foot
+# Scheme name: Da One Paper
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=181818
 background=faf0dc
@@ -16,7 +14,7 @@ regular4=5890f8 # blue
 regular5=c173d1 # magenta
 regular6=64b5a7 # cyan
 regular7=181818 # white
-bright0=585858 # bright black
+bright0=888888 # bright black
 bright1=de5d6e # bright red
 bright2=76a85d # bright green
 bright3=b3684f # bright yellow

--- a/colors/base16-da-one-sea.ini
+++ b/colors/base16-da-one-sea.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Da One Sea 
+# tinted-foot
+# Scheme name: Da One Sea
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ffffff
 background=22273d
@@ -16,7 +14,7 @@ regular4=6bb8ff # blue
 regular5=e799ff # magenta
 regular6=8af5ff # cyan
 regular7=ffffff # white
-bright0=878d96 # bright black
+bright0=525866 # bright black
 bright1=fa7883 # bright red
 bright2=98c379 # bright green
 bright3=ff9470 # bright yellow

--- a/colors/base16-da-one-white.ini
+++ b/colors/base16-da-one-white.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Da One White 
+# tinted-foot
+# Scheme name: Da One White
 # Scheme author: NNB (https://github.com/NNBnh)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=181818
 background=ffffff
@@ -16,7 +14,7 @@ regular4=5890f8 # blue
 regular5=c173d1 # magenta
 regular6=64b5a7 # cyan
 regular7=181818 # white
-bright0=585858 # bright black
+bright0=888888 # bright black
 bright1=de5d6e # bright red
 bright2=76a85d # bright green
 bright3=b3684f # bright yellow

--- a/colors/base16-danqing-light.ini
+++ b/colors/base16-danqing-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: DanQing Light 
+# tinted-foot
+# Scheme name: DanQing Light
 # Scheme author: Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5a605d
 background=fcfefd
@@ -16,7 +14,7 @@ regular4=b0a4e3 # blue
 regular5=cca4e3 # magenta
 regular6=30dff3 # cyan
 regular7=5a605d # white
-bright0=cad8d2 # bright black
+bright0=e0f0ef # bright black
 bright1=f9906f # bright red
 bright2=8ab361 # bright green
 bright3=f0c239 # bright yellow

--- a/colors/base16-danqing.ini
+++ b/colors/base16-danqing.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: DanQing 
+# tinted-foot
+# Scheme name: DanQing
 # Scheme author: Wenhan Zhu (Cosmos) (zhuwenhan950913@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e0f0ef
 background=2d302f
@@ -16,7 +14,7 @@ regular4=b0a4e3 # blue
 regular5=cca4e3 # magenta
 regular6=30dff3 # cyan
 regular7=e0f0ef # white
-bright0=9da8a3 # bright black
+bright0=5a605d # bright black
 bright1=f9906f # bright red
 bright2=8ab361 # bright green
 bright3=f0c239 # bright yellow

--- a/colors/base16-darcula.ini
+++ b/colors/base16-darcula.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Darcula 
+# tinted-foot
+# Scheme name: Darcula
 # Scheme author: jetbrains
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a9b7c6
 background=2b2b2b
@@ -16,7 +14,7 @@ regular4=9876aa # blue
 regular5=cc7832 # magenta
 regular6=629755 # cyan
 regular7=a9b7c6 # white
-bright0=606366 # bright black
+bright0=323232 # bright black
 bright1=4eade5 # bright red
 bright2=6a8759 # bright green
 bright3=bbb529 # bright yellow

--- a/colors/base16-darkmoss.ini
+++ b/colors/base16-darkmoss.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: darkmoss 
+# tinted-foot
+# Scheme name: darkmoss
 # Scheme author: Gabriel Avanzi (https://github.com/avanzzzi)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c7c7a5
 background=171e1f
@@ -16,7 +14,7 @@ regular4=498091 # blue
 regular5=9bc0c8 # magenta
 regular6=66d9ef # cyan
 regular7=c7c7a5 # white
-bright0=555e5f # bright black
+bright0=373c3d # bright black
 bright1=ff4658 # bright red
 bright2=499180 # bright green
 bright3=fdb11f # bright yellow

--- a/colors/base16-darktooth.ini
+++ b/colors/base16-darktooth.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Darktooth 
+# tinted-foot
+# Scheme name: Darktooth
 # Scheme author: Jason Milkins (https://github.com/jasonm23)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a89984
 background=1d2021
@@ -16,7 +14,7 @@ regular4=0d6678 # blue
 regular5=8f4673 # magenta
 regular6=8ba59b # cyan
 regular7=a89984 # white
-bright0=665c54 # bright black
+bright0=504945 # bright black
 bright1=fb543f # bright red
 bright2=95c085 # bright green
 bright3=fac03b # bright yellow

--- a/colors/base16-darkviolet.ini
+++ b/colors/base16-darkviolet.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Dark Violet 
+# tinted-foot
+# Scheme name: Dark Violet
 # Scheme author: ruler501 (https://github.com/ruler501/base16-darkviolet)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b08ae6
 background=000000
@@ -16,7 +14,7 @@ regular4=4136d9 # blue
 regular5=7e5ce6 # magenta
 regular6=40dfff # cyan
 regular7=b08ae6 # white
-bright0=593380 # bright black
+bright0=432d59 # bright black
 bright1=a82ee6 # bright red
 bright2=4595e6 # bright green
 bright3=f29df2 # bright yellow

--- a/colors/base16-decaf.ini
+++ b/colors/base16-decaf.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Decaf 
+# tinted-foot
+# Scheme name: Decaf
 # Scheme author: Alex Mirrington (https://github.com/alexmirrington)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cccccc
 background=2d2d2d
@@ -16,7 +14,7 @@ regular4=90bee1 # blue
 regular5=efb3f7 # magenta
 regular6=bed6ff # cyan
 regular7=cccccc # white
-bright0=777777 # bright black
+bright0=515151 # bright black
 bright1=ff7f7b # bright red
 bright2=beda78 # bright green
 bright3=ffd67c # bright yellow

--- a/colors/base16-default-dark.ini
+++ b/colors/base16-default-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Default Dark 
+# tinted-foot
+# Scheme name: Default Dark
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d8d8d8
 background=181818
@@ -16,7 +14,7 @@ regular4=7cafc2 # blue
 regular5=ba8baf # magenta
 regular6=86c1b9 # cyan
 regular7=d8d8d8 # white
-bright0=585858 # bright black
+bright0=383838 # bright black
 bright1=ab4642 # bright red
 bright2=a1b56c # bright green
 bright3=f7ca88 # bright yellow

--- a/colors/base16-default-light.ini
+++ b/colors/base16-default-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Default Light 
+# tinted-foot
+# Scheme name: Default Light
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=383838
 background=f8f8f8
@@ -16,7 +14,7 @@ regular4=7cafc2 # blue
 regular5=ba8baf # magenta
 regular6=86c1b9 # cyan
 regular7=383838 # white
-bright0=b8b8b8 # bright black
+bright0=d8d8d8 # bright black
 bright1=ab4642 # bright red
 bright2=a1b56c # bright green
 bright3=f7ca88 # bright yellow

--- a/colors/base16-dirtysea.ini
+++ b/colors/base16-dirtysea.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: dirtysea 
+# tinted-foot
+# Scheme name: dirtysea
 # Scheme author: Kahlil (Kal) Hodgson
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=000000
 background=e0e0e0
@@ -16,7 +14,7 @@ regular4=007300 # blue
 regular5=000090 # magenta
 regular6=755b00 # cyan
 regular7=000000 # white
-bright0=707070 # bright black
+bright0=d0d0d0 # bright black
 bright1=840000 # bright red
 bright2=730073 # bright green
 bright3=755b00 # bright yellow

--- a/colors/base16-dracula.ini
+++ b/colors/base16-dracula.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Dracula 
+# tinted-foot
+# Scheme name: Dracula
 # Scheme author: Jamy Golden (http://github.com/JamyGolden), based on Dracula Theme (http://github.com/dracula)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=f8f8f2
 background=282a36
@@ -16,7 +14,7 @@ regular4=80bfff # blue
 regular5=ff79c6 # magenta
 regular6=8be9fd # cyan
 regular7=f8f8f2 # white
-bright0=6272a4 # bright black
+bright0=44475a # bright black
 bright1=ff5555 # bright red
 bright2=50fa7b # bright green
 bright3=f1fa8c # bright yellow

--- a/colors/base16-edge-dark.ini
+++ b/colors/base16-edge-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Edge Dark 
+# tinted-foot
+# Scheme name: Edge Dark
 # Scheme author: cjayross (https://github.com/cjayross)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b7bec9
 background=262729
@@ -16,7 +14,7 @@ regular4=73b3e7 # blue
 regular5=d390e7 # magenta
 regular6=5ebaa5 # cyan
 regular7=b7bec9 # white
-bright0=3e4249 # bright black
+bright0=b7bec9 # bright black
 bright1=e77171 # bright red
 bright2=a1bf78 # bright green
 bright3=dbb774 # bright yellow

--- a/colors/base16-edge-light.ini
+++ b/colors/base16-edge-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Edge Light 
+# tinted-foot
+# Scheme name: Edge Light
 # Scheme author: cjayross (https://github.com/cjayross)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5e646f
 background=fafafa
@@ -16,7 +14,7 @@ regular4=6587bf # blue
 regular5=b870ce # magenta
 regular6=509c93 # cyan
 regular7=5e646f # white
-bright0=5e646f # bright black
+bright0=d69822 # bright black
 bright1=db7070 # bright red
 bright2=7c9f4b # bright green
 bright3=d69822 # bright yellow

--- a/colors/base16-eighties.ini
+++ b/colors/base16-eighties.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Eighties 
+# tinted-foot
+# Scheme name: Eighties
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d3d0c8
 background=2d2d2d
@@ -16,7 +14,7 @@ regular4=6699cc # blue
 regular5=cc99cc # magenta
 regular6=66cccc # cyan
 regular7=d3d0c8 # white
-bright0=747369 # bright black
+bright0=515151 # bright black
 bright1=f2777a # bright red
 bright2=99cc99 # bright green
 bright3=ffcc66 # bright yellow

--- a/colors/base16-embers-light.ini
+++ b/colors/base16-embers-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Embers Light 
+# tinted-foot
+# Scheme name: Embers Light
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=323b43
 background=d1d6db
@@ -16,7 +14,7 @@ regular4=82576d # blue
 regular5=6d5782 # magenta
 regular6=826d57 # cyan
 regular7=323b43 # white
-bright0=75808a # bright black
+bright0=909aa3 # bright black
 bright1=576d82 # bright red
 bright2=6d8257 # bright green
 bright3=57826d # bright yellow

--- a/colors/base16-embers.ini
+++ b/colors/base16-embers.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Embers 
+# tinted-foot
+# Scheme name: Embers
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a39a90
 background=16130f
@@ -16,7 +14,7 @@ regular4=6d5782 # blue
 regular5=82576d # magenta
 regular6=576d82 # cyan
 regular7=a39a90 # white
-bright0=5a5047 # bright black
+bright0=433b32 # bright black
 bright1=826d57 # bright red
 bright2=57826d # bright green
 bright3=6d8257 # bright yellow

--- a/colors/base16-emil.ini
+++ b/colors/base16-emil.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: emil 
+# tinted-foot
+# Scheme name: emil
 # Scheme author: limelier
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=313145
 background=efefef
@@ -16,7 +14,7 @@ regular4=471397 # blue
 regular5=6916b6 # magenta
 regular6=2155d6 # cyan
 regular7=313145 # white
-bright0=7c7c98 # bright black
+bright0=9e9eaf # bright black
 bright1=f43979 # bright red
 bright2=0073a8 # bright green
 bright3=ff669b # bright yellow

--- a/colors/base16-equilibrium-dark.ini
+++ b/colors/base16-equilibrium-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Equilibrium Dark 
+# tinted-foot
+# Scheme name: Equilibrium Dark
 # Scheme author: Carlo Abelli
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=afaba2
 background=0c1118
@@ -16,7 +14,7 @@ regular4=008dd1 # blue
 regular5=6a7fd2 # magenta
 regular6=00948b # cyan
 regular7=afaba2 # white
-bright0=7b776e # bright black
+bright0=22262d # bright black
 bright1=f04339 # bright red
 bright2=7f8b00 # bright green
 bright3=bb8801 # bright yellow

--- a/colors/base16-equilibrium-gray-dark.ini
+++ b/colors/base16-equilibrium-gray-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Equilibrium Gray Dark 
+# tinted-foot
+# Scheme name: Equilibrium Gray Dark
 # Scheme author: Carlo Abelli
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ababab
 background=111111
@@ -16,7 +14,7 @@ regular4=008dd1 # blue
 regular5=6a7fd2 # magenta
 regular6=00948b # cyan
 regular7=ababab # white
-bright0=777777 # bright black
+bright0=262626 # bright black
 bright1=f04339 # bright red
 bright2=7f8b00 # bright green
 bright3=bb8801 # bright yellow

--- a/colors/base16-equilibrium-gray-light.ini
+++ b/colors/base16-equilibrium-gray-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Equilibrium Gray Light 
+# tinted-foot
+# Scheme name: Equilibrium Gray Light
 # Scheme author: Carlo Abelli
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=474747
 background=f1f1f1
@@ -16,7 +14,7 @@ regular4=0073b5 # blue
 regular5=4e66b6 # magenta
 regular6=007a72 # cyan
 regular7=474747 # white
-bright0=777777 # bright black
+bright0=d4d4d4 # bright black
 bright1=d02023 # bright red
 bright2=637200 # bright green
 bright3=9d6f00 # bright yellow

--- a/colors/base16-equilibrium-light.ini
+++ b/colors/base16-equilibrium-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Equilibrium Light 
+# tinted-foot
+# Scheme name: Equilibrium Light
 # Scheme author: Carlo Abelli
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=43474e
 background=f5f0e7
@@ -16,7 +14,7 @@ regular4=0073b5 # blue
 regular5=4e66b6 # magenta
 regular6=007a72 # cyan
 regular7=43474e # white
-bright0=73777f # bright black
+bright0=d8d4cb # bright black
 bright1=d02023 # bright red
 bright2=637200 # bright green
 bright3=9d6f00 # bright yellow

--- a/colors/base16-eris.ini
+++ b/colors/base16-eris.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: eris 
+# tinted-foot
+# Scheme name: eris
 # Scheme author: ed (https://codeberg.org/ed)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=606bac
 background=0a0920
@@ -16,7 +14,7 @@ regular4=258fc4 # blue
 regular5=f768a3 # magenta
 regular6=258fc4 # cyan
 regular7=606bac # white
-bright0=333773 # bright black
+bright0=23255a # bright black
 bright1=f768a3 # bright red
 bright2=faaea2 # bright green
 bright3=faaea2 # bright yellow

--- a/colors/base16-espresso.ini
+++ b/colors/base16-espresso.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Espresso 
+# tinted-foot
+# Scheme name: Espresso
 # Scheme author: Unknown. Maintained by Alex Mirrington (https://github.com/alexmirrington)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cccccc
 background=2d2d2d
@@ -16,7 +14,7 @@ regular4=6c99bb # blue
 regular5=d197d9 # magenta
 regular6=bed6ff # cyan
 regular7=cccccc # white
-bright0=777777 # bright black
+bright0=515151 # bright black
 bright1=d25252 # bright red
 bright2=a5c261 # bright green
 bright3=ffc66d # bright yellow

--- a/colors/base16-eva-dim.ini
+++ b/colors/base16-eva-dim.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Eva Dim 
+# tinted-foot
+# Scheme name: Eva Dim
 # Scheme author: kjakapat (https://github.com/kjakapat)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=9fa2a6
 background=2a3b4d
@@ -16,7 +14,7 @@ regular4=1ae1dc # blue
 regular5=9c6cd3 # magenta
 regular6=4b8f77 # cyan
 regular7=9fa2a6 # white
-bright0=55799c # bright black
+bright0=4b6988 # bright black
 bright1=c4676c # bright red
 bright2=5de561 # bright green
 bright3=cfd05d # bright yellow

--- a/colors/base16-eva.ini
+++ b/colors/base16-eva.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Eva 
+# tinted-foot
+# Scheme name: Eva
 # Scheme author: kjakapat (https://github.com/kjakapat)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=9fa2a6
 background=2a3b4d
@@ -16,7 +14,7 @@ regular4=15f4ee # blue
 regular5=9c6cd3 # magenta
 regular6=4b8f77 # cyan
 regular7=9fa2a6 # white
-bright0=55799c # bright black
+bright0=4b6988 # bright black
 bright1=c4676c # bright red
 bright2=66ff66 # bright green
 bright3=ffff66 # bright yellow

--- a/colors/base16-evenok-dark.ini
+++ b/colors/base16-evenok-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Evenok Dark 
+# tinted-foot
+# Scheme name: Evenok Dark
 # Scheme author: Mekeor Melire
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d0d0d0
 background=000000
@@ -16,7 +14,7 @@ regular4=00aff2 # blue
 regular5=9095ff # magenta
 regular6=00bab3 # cyan
 regular7=d0d0d0 # white
-bright0=505050 # bright black
+bright0=303030 # bright black
 bright1=f5708a # bright red
 bright2=54bc5c # bright green
 bright3=b8a300 # bright yellow

--- a/colors/base16-everforest-dark-hard.ini
+++ b/colors/base16-everforest-dark-hard.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Everforest Dark Hard 
+# tinted-foot
+# Scheme name: Everforest Dark Hard
 # Scheme author: Sainnhe Park (https://github.com/sainnhe)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d3c6aa
 background=272e33
@@ -16,7 +14,7 @@ regular4=7fbbb3 # blue
 regular5=d699b6 # magenta
 regular6=83c092 # cyan
 regular7=d3c6aa # white
-bright0=859289 # bright black
+bright0=414b50 # bright black
 bright1=e67e80 # bright red
 bright2=a7c080 # bright green
 bright3=dbbc7f # bright yellow

--- a/colors/base16-everforest.ini
+++ b/colors/base16-everforest.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Everforest 
+# tinted-foot
+# Scheme name: Everforest
 # Scheme author: Sainnhe Park (https://github.com/sainnhe)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d3c6aa
 background=2d353b
@@ -16,7 +14,7 @@ regular4=7fbbb3 # blue
 regular5=d699b6 # magenta
 regular6=83c092 # cyan
 regular7=d3c6aa # white
-bright0=859289 # bright black
+bright0=475258 # bright black
 bright1=e67e80 # bright red
 bright2=a7c080 # bright green
 bright3=dbbc7f # bright yellow

--- a/colors/base16-flat.ini
+++ b/colors/base16-flat.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Flat 
+# tinted-foot
+# Scheme name: Flat
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e0e0e0
 background=2c3e50
@@ -16,7 +14,7 @@ regular4=3498db # blue
 regular5=9b59b6 # magenta
 regular6=1abc9c # cyan
 regular7=e0e0e0 # white
-bright0=95a5a6 # bright black
+bright0=7f8c8d # bright black
 bright1=e74c3c # bright red
 bright2=2ecc71 # bright green
 bright3=f1c40f # bright yellow

--- a/colors/base16-framer.ini
+++ b/colors/base16-framer.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Framer 
+# tinted-foot
+# Scheme name: Framer
 # Scheme author: Framer (Maintained by Jesse Hoyos)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d0d0d0
 background=181818
@@ -16,7 +14,7 @@ regular4=20bcfc # blue
 regular5=ba8cfc # magenta
 regular6=acddfd # cyan
 regular7=d0d0d0 # white
-bright0=747474 # bright black
+bright0=464646 # bright black
 bright1=fd886b # bright red
 bright2=32ccdc # bright green
 bright3=fecb6e # bright yellow

--- a/colors/base16-fruit-soda.ini
+++ b/colors/base16-fruit-soda.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Fruit Soda 
+# tinted-foot
+# Scheme name: Fruit Soda
 # Scheme author: jozip
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=515151
 background=f1ecf1
@@ -16,7 +14,7 @@ regular4=2931df # blue
 regular5=611fce # magenta
 regular6=0f9cfd # cyan
 regular7=515151 # white
-bright0=b5b4b6 # bright black
+bright0=d8d5d5 # bright black
 bright1=fe3e31 # bright red
 bright2=47f74c # bright green
 bright3=f7e203 # bright yellow

--- a/colors/base16-gigavolt.ini
+++ b/colors/base16-gigavolt.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gigavolt 
+# tinted-foot
+# Scheme name: Gigavolt
 # Scheme author: Aidan Swope (http://github.com/Whillikers)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e9e7e1
 background=202126
@@ -16,7 +14,7 @@ regular4=40bfff # blue
 regular5=ae94f9 # magenta
 regular6=fb6acb # cyan
 regular7=e9e7e1 # white
-bright0=a1d2e6 # bright black
+bright0=5a576e # bright black
 bright1=ff661a # bright red
 bright2=f2e6a9 # bright green
 bright3=ffdc2d # bright yellow

--- a/colors/base16-github.ini
+++ b/colors/base16-github.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Github 
+# tinted-foot
+# Scheme name: Github
 # Scheme author: Defman21
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=333333
 background=ffffff
@@ -16,7 +14,7 @@ regular4=795da3 # blue
 regular5=a71d5d # magenta
 regular6=183691 # cyan
 regular7=333333 # white
-bright0=969896 # bright black
+bright0=c8c8fa # bright black
 bright1=ed6a43 # bright red
 bright2=183691 # bright green
 bright3=795da3 # bright yellow

--- a/colors/base16-google-dark.ini
+++ b/colors/base16-google-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Google Dark 
+# tinted-foot
+# Scheme name: Google Dark
 # Scheme author: Seth Wright (http://sethawright.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c5c8c6
 background=1d1f21
@@ -16,7 +14,7 @@ regular4=3971ed # blue
 regular5=a36ac7 # magenta
 regular6=3971ed # cyan
 regular7=c5c8c6 # white
-bright0=969896 # bright black
+bright0=373b41 # bright black
 bright1=cc342b # bright red
 bright2=198844 # bright green
 bright3=fba922 # bright yellow

--- a/colors/base16-google-light.ini
+++ b/colors/base16-google-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Google Light 
+# tinted-foot
+# Scheme name: Google Light
 # Scheme author: Seth Wright (http://sethawright.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=373b41
 background=ffffff
@@ -16,7 +14,7 @@ regular4=3971ed # blue
 regular5=a36ac7 # magenta
 regular6=3971ed # cyan
 regular7=373b41 # white
-bright0=b4b7b4 # bright black
+bright0=c5c8c6 # bright black
 bright1=cc342b # bright red
 bright2=198844 # bright green
 bright3=fba922 # bright yellow

--- a/colors/base16-gotham.ini
+++ b/colors/base16-gotham.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gotham 
+# tinted-foot
+# Scheme name: Gotham
 # Scheme author: Andrea Leopardi (arranged by Brett Jones)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=599cab
 background=0c1014
@@ -16,7 +14,7 @@ regular4=195466 # blue
 regular5=888ca6 # magenta
 regular6=2aa889 # cyan
 regular7=599cab # white
-bright0=0a3749 # bright black
+bright0=091f2e # bright black
 bright1=c23127 # bright red
 bright2=33859e # bright green
 bright3=edb443 # bright yellow

--- a/colors/base16-grayscale-dark.ini
+++ b/colors/base16-grayscale-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Grayscale Dark 
+# tinted-foot
+# Scheme name: Grayscale Dark
 # Scheme author: Alexandre Gavioli (https://github.com/Alexx2/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b9b9b9
 background=101010
@@ -16,7 +14,7 @@ regular4=686868 # blue
 regular5=747474 # magenta
 regular6=868686 # cyan
 regular7=b9b9b9 # white
-bright0=525252 # bright black
+bright0=464646 # bright black
 bright1=7c7c7c # bright red
 bright2=8e8e8e # bright green
 bright3=a0a0a0 # bright yellow

--- a/colors/base16-grayscale-light.ini
+++ b/colors/base16-grayscale-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Grayscale Light 
+# tinted-foot
+# Scheme name: Grayscale Light
 # Scheme author: Alexandre Gavioli (https://github.com/Alexx2/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=464646
 background=f7f7f7
@@ -16,7 +14,7 @@ regular4=686868 # blue
 regular5=747474 # magenta
 regular6=868686 # cyan
 regular7=464646 # white
-bright0=ababab # bright black
+bright0=b9b9b9 # bright black
 bright1=7c7c7c # bright red
 bright2=8e8e8e # bright green
 bright3=a0a0a0 # bright yellow

--- a/colors/base16-greenscreen.ini
+++ b/colors/base16-greenscreen.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Green Screen 
+# tinted-foot
+# Scheme name: Green Screen
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=00bb00
 background=001100
@@ -16,7 +14,7 @@ regular4=009900 # blue
 regular5=00bb00 # magenta
 regular6=005500 # cyan
 regular7=00bb00 # white
-bright0=007700 # bright black
+bright0=005500 # bright black
 bright1=007700 # bright red
 bright2=00bb00 # bright green
 bright3=007700 # bright yellow

--- a/colors/base16-gruber.ini
+++ b/colors/base16-gruber.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruber 
+# tinted-foot
+# Scheme name: Gruber
 # Scheme author: Patel, Nimai &lt;nimai.m.patel@gmail.com&gt;, colors from www.github.com/rexim/gruber-darker-theme
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=f4f4ff
 background=181818
@@ -16,7 +14,7 @@ regular4=96a6c8 # blue
 regular5=9e95c7 # magenta
 regular6=95a99f # cyan
 regular7=f4f4ff # white
-bright0=52494e # bright black
+bright0=484848 # bright black
 bright1=f43841 # bright red
 bright2=73c936 # bright green
 bright3=ffdd33 # bright yellow

--- a/colors/base16-gruvbox-dark-hard.ini
+++ b/colors/base16-gruvbox-dark-hard.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox dark, hard 
+# tinted-foot
+# Scheme name: Gruvbox dark, hard
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d5c4a1
 background=1d2021
@@ -16,7 +14,7 @@ regular4=83a598 # blue
 regular5=d3869b # magenta
 regular6=8ec07c # cyan
 regular7=d5c4a1 # white
-bright0=665c54 # bright black
+bright0=504945 # bright black
 bright1=fb4934 # bright red
 bright2=b8bb26 # bright green
 bright3=fabd2f # bright yellow

--- a/colors/base16-gruvbox-dark-medium.ini
+++ b/colors/base16-gruvbox-dark-medium.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox dark, medium 
+# tinted-foot
+# Scheme name: Gruvbox dark, medium
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d5c4a1
 background=282828
@@ -16,7 +14,7 @@ regular4=83a598 # blue
 regular5=d3869b # magenta
 regular6=8ec07c # cyan
 regular7=d5c4a1 # white
-bright0=665c54 # bright black
+bright0=504945 # bright black
 bright1=fb4934 # bright red
 bright2=b8bb26 # bright green
 bright3=fabd2f # bright yellow

--- a/colors/base16-gruvbox-dark-pale.ini
+++ b/colors/base16-gruvbox-dark-pale.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox dark, pale 
+# tinted-foot
+# Scheme name: Gruvbox dark, pale
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=dab997
 background=262626
@@ -16,7 +14,7 @@ regular4=83adad # blue
 regular5=d485ad # magenta
 regular6=85ad85 # cyan
 regular7=dab997 # white
-bright0=8a8a8a # bright black
+bright0=4e4e4e # bright black
 bright1=d75f5f # bright red
 bright2=afaf00 # bright green
 bright3=ffaf00 # bright yellow

--- a/colors/base16-gruvbox-dark-soft.ini
+++ b/colors/base16-gruvbox-dark-soft.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox dark, soft 
+# tinted-foot
+# Scheme name: Gruvbox dark, soft
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d5c4a1
 background=32302f
@@ -16,7 +14,7 @@ regular4=83a598 # blue
 regular5=d3869b # magenta
 regular6=8ec07c # cyan
 regular7=d5c4a1 # white
-bright0=665c54 # bright black
+bright0=504945 # bright black
 bright1=fb4934 # bright red
 bright2=b8bb26 # bright green
 bright3=fabd2f # bright yellow

--- a/colors/base16-gruvbox-light-hard.ini
+++ b/colors/base16-gruvbox-light-hard.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox light, hard 
+# tinted-foot
+# Scheme name: Gruvbox light, hard
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=504945
 background=f9f5d7
@@ -16,7 +14,7 @@ regular4=076678 # blue
 regular5=8f3f71 # magenta
 regular6=427b58 # cyan
 regular7=504945 # white
-bright0=bdae93 # bright black
+bright0=d5c4a1 # bright black
 bright1=9d0006 # bright red
 bright2=79740e # bright green
 bright3=b57614 # bright yellow

--- a/colors/base16-gruvbox-light-medium.ini
+++ b/colors/base16-gruvbox-light-medium.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox light, medium 
+# tinted-foot
+# Scheme name: Gruvbox light, medium
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=504945
 background=fbf1c7
@@ -16,7 +14,7 @@ regular4=076678 # blue
 regular5=8f3f71 # magenta
 regular6=427b58 # cyan
 regular7=504945 # white
-bright0=bdae93 # bright black
+bright0=d5c4a1 # bright black
 bright1=9d0006 # bright red
 bright2=79740e # bright green
 bright3=b57614 # bright yellow

--- a/colors/base16-gruvbox-light-soft.ini
+++ b/colors/base16-gruvbox-light-soft.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox light, soft 
+# tinted-foot
+# Scheme name: Gruvbox light, soft
 # Scheme author: Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=504945
 background=f2e5bc
@@ -16,7 +14,7 @@ regular4=076678 # blue
 regular5=8f3f71 # magenta
 regular6=427b58 # cyan
 regular7=504945 # white
-bright0=bdae93 # bright black
+bright0=d5c4a1 # bright black
 bright1=9d0006 # bright red
 bright2=79740e # bright green
 bright3=b57614 # bright yellow

--- a/colors/base16-gruvbox-material-dark-hard.ini
+++ b/colors/base16-gruvbox-material-dark-hard.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox Material Dark, Hard 
+# tinted-foot
+# Scheme name: Gruvbox Material Dark, Hard
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ddc7a1
 background=202020
@@ -16,7 +14,7 @@ regular4=7daea3 # blue
 regular5=d3869b # magenta
 regular6=89b482 # cyan
 regular7=ddc7a1 # white
-bright0=5a524c # bright black
+bright0=504945 # bright black
 bright1=ea6962 # bright red
 bright2=a9b665 # bright green
 bright3=d8a657 # bright yellow

--- a/colors/base16-gruvbox-material-dark-medium.ini
+++ b/colors/base16-gruvbox-material-dark-medium.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox Material Dark, Medium 
+# tinted-foot
+# Scheme name: Gruvbox Material Dark, Medium
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ddc7a1
 background=292828
@@ -16,7 +14,7 @@ regular4=7daea3 # blue
 regular5=d3869b # magenta
 regular6=89b482 # cyan
 regular7=ddc7a1 # white
-bright0=665c54 # bright black
+bright0=504945 # bright black
 bright1=ea6962 # bright red
 bright2=a9b665 # bright green
 bright3=d8a657 # bright yellow

--- a/colors/base16-gruvbox-material-dark-soft.ini
+++ b/colors/base16-gruvbox-material-dark-soft.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox Material Dark, Soft 
+# tinted-foot
+# Scheme name: Gruvbox Material Dark, Soft
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ddc7a1
 background=32302f
@@ -16,7 +14,7 @@ regular4=7daea3 # blue
 regular5=d3869b # magenta
 regular6=89b482 # cyan
 regular7=ddc7a1 # white
-bright0=7c6f64 # bright black
+bright0=5a524c # bright black
 bright1=ea6962 # bright red
 bright2=a9b665 # bright green
 bright3=d8a657 # bright yellow

--- a/colors/base16-gruvbox-material-light-hard.ini
+++ b/colors/base16-gruvbox-material-light-hard.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox Material Light, Hard 
+# tinted-foot
+# Scheme name: Gruvbox Material Light, Hard
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=654735
 background=f9f5d7
@@ -16,7 +14,7 @@ regular4=45707a # blue
 regular5=945e80 # magenta
 regular6=4c7a5d # cyan
 regular7=654735 # white
-bright0=a89984 # bright black
+bright0=e0cfa9 # bright black
 bright1=c14a4a # bright red
 bright2=6c782e # bright green
 bright3=b47109 # bright yellow

--- a/colors/base16-gruvbox-material-light-medium.ini
+++ b/colors/base16-gruvbox-material-light-medium.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox Material Light, Medium 
+# tinted-foot
+# Scheme name: Gruvbox Material Light, Medium
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=654735
 background=fbf1c7
@@ -16,7 +14,7 @@ regular4=45707a # blue
 regular5=945e80 # magenta
 regular6=4c7a5d # cyan
 regular7=654735 # white
-bright0=bdae93 # bright black
+bright0=d5c4a1 # bright black
 bright1=c14a4a # bright red
 bright2=6c782e # bright green
 bright3=b47109 # bright yellow

--- a/colors/base16-gruvbox-material-light-soft.ini
+++ b/colors/base16-gruvbox-material-light-soft.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Gruvbox Material Light, Soft 
+# tinted-foot
+# Scheme name: Gruvbox Material Light, Soft
 # Scheme author: Mayush Kumar (https://github.com/MayushKumar), sainnhe (https://github.com/sainnhe/gruvbox-material-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=654735
 background=f2e5bc
@@ -16,7 +14,7 @@ regular4=45707a # blue
 regular5=945e80 # magenta
 regular6=4c7a5d # cyan
 regular7=654735 # white
-bright0=a89984 # bright black
+bright0=c9b99a # bright black
 bright1=c14a4a # bright red
 bright2=6c782e # bright green
 bright3=b47109 # bright yellow

--- a/colors/base16-hardcore.ini
+++ b/colors/base16-hardcore.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Hardcore 
+# tinted-foot
+# Scheme name: Hardcore
 # Scheme author: Chris Caller
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cdcdcd
 background=212121
@@ -16,7 +14,7 @@ regular4=66d9ef # blue
 regular5=9e6ffe # magenta
 regular6=708387 # cyan
 regular7=cdcdcd # white
-bright0=4a4a4a # bright black
+bright0=353535 # bright black
 bright1=f92672 # bright red
 bright2=a6e22e # bright green
 bright3=e6db74 # bright yellow

--- a/colors/base16-harmonic16-dark.ini
+++ b/colors/base16-harmonic16-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Harmonic16 Dark 
+# tinted-foot
+# Scheme name: Harmonic16 Dark
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cbd6e2
 background=0b1c2c
@@ -16,7 +14,7 @@ regular4=8b56bf # blue
 regular5=bf568b # magenta
 regular6=568bbf # cyan
 regular7=cbd6e2 # white
-bright0=627e99 # bright black
+bright0=405c79 # bright black
 bright1=bf8b56 # bright red
 bright2=56bf8b # bright green
 bright3=8bbf56 # bright yellow

--- a/colors/base16-harmonic16-light.ini
+++ b/colors/base16-harmonic16-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Harmonic16 Light 
+# tinted-foot
+# Scheme name: Harmonic16 Light
 # Scheme author: Jannik Siebert (https://github.com/janniks)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=405c79
 background=f7f9fb
@@ -16,7 +14,7 @@ regular4=8b56bf # blue
 regular5=bf568b # magenta
 regular6=568bbf # cyan
 regular7=405c79 # white
-bright0=aabcce # bright black
+bright0=cbd6e2 # bright black
 bright1=bf8b56 # bright red
 bright2=56bf8b # bright green
 bright3=8bbf56 # bright yellow

--- a/colors/base16-heetch-light.ini
+++ b/colors/base16-heetch-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Heetch Light 
+# tinted-foot
+# Scheme name: Heetch Light
 # Scheme author: Geoffrey Teale (tealeg@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5a496e
 background=feffff
@@ -16,7 +14,7 @@ regular4=47f9f5 # blue
 regular5=bd0152 # magenta
 regular6=c33678 # cyan
 regular7=5a496e # white
-bright0=9c92a8 # bright black
+bright0=7b6d8b # bright black
 bright1=27d9d5 # bright red
 bright2=f80059 # bright green
 bright3=5ba2b6 # bright yellow

--- a/colors/base16-heetch.ini
+++ b/colors/base16-heetch.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Heetch Dark 
+# tinted-foot
+# Scheme name: Heetch Dark
 # Scheme author: Geoffrey Teale (tealeg@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=bdb6c5
 background=190134
@@ -16,7 +14,7 @@ regular4=bd0152 # blue
 regular5=82034c # magenta
 regular6=f80059 # cyan
 regular7=bdb6c5 # white
-bright0=7b6d8b # bright black
+bright0=5a496e # bright black
 bright1=27d9d5 # bright red
 bright2=c33678 # bright green
 bright3=8f6c97 # bright yellow

--- a/colors/base16-helios.ini
+++ b/colors/base16-helios.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Helios 
+# tinted-foot
+# Scheme name: Helios
 # Scheme author: Alex Meyer (https://github.com/reyemxela)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d5d5d5
 background=1d2021
@@ -16,7 +14,7 @@ regular4=1e8bac # blue
 regular5=be4264 # magenta
 regular6=1ba595 # cyan
 regular7=d5d5d5 # white
-bright0=6f7579 # bright black
+bright0=53585b # bright black
 bright1=d72638 # bright red
 bright2=88b92d # bright green
 bright3=f19d1a # bright yellow

--- a/colors/base16-hopscotch.ini
+++ b/colors/base16-hopscotch.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Hopscotch 
+# tinted-foot
+# Scheme name: Hopscotch
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b9b5b8
 background=322931
@@ -16,7 +14,7 @@ regular4=1290bf # blue
 regular5=c85e7c # magenta
 regular6=149b93 # cyan
 regular7=b9b5b8 # white
-bright0=797379 # bright black
+bright0=5c545b # bright black
 bright1=dd464c # bright red
 bright2=8fc13e # bright green
 bright3=fdcc59 # bright yellow

--- a/colors/base16-horizon-dark.ini
+++ b/colors/base16-horizon-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Horizon Dark 
+# tinted-foot
+# Scheme name: Horizon Dark
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cbced0
 background=1c1e26
@@ -16,7 +14,7 @@ regular4=df5273 # blue
 regular5=b072d1 # magenta
 regular6=24a8b4 # cyan
 regular7=cbced0 # white
-bright0=6f6f70 # bright black
+bright0=2e303e # bright black
 bright1=e93c58 # bright red
 bright2=efaf8e # bright green
 bright3=efb993 # bright yellow

--- a/colors/base16-horizon-light.ini
+++ b/colors/base16-horizon-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Horizon Light 
+# tinted-foot
+# Scheme name: Horizon Light
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=403c3d
 background=fdf0ed
@@ -16,7 +14,7 @@ regular4=da103f # blue
 regular5=1d8991 # magenta
 regular6=dc3318 # cyan
 regular7=403c3d # white
-bright0=bdb3b1 # bright black
+bright0=f9cbbe # bright black
 bright1=f7939b # bright red
 bright2=94e1b0 # bright green
 bright3=fbe0d9 # bright yellow

--- a/colors/base16-horizon-terminal-dark.ini
+++ b/colors/base16-horizon-terminal-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Horizon Terminal Dark 
+# tinted-foot
+# Scheme name: Horizon Terminal Dark
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cbced0
 background=1c1e26
@@ -16,7 +14,7 @@ regular4=26bbd9 # blue
 regular5=ee64ac # magenta
 regular6=59e1e3 # cyan
 regular7=cbced0 # white
-bright0=6f6f70 # bright black
+bright0=2e303e # bright black
 bright1=e95678 # bright red
 bright2=29d398 # bright green
 bright3=fac29a # bright yellow

--- a/colors/base16-horizon-terminal-light.ini
+++ b/colors/base16-horizon-terminal-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Horizon Terminal Light 
+# tinted-foot
+# Scheme name: Horizon Terminal Light
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=403c3d
 background=fdf0ed
@@ -16,7 +14,7 @@ regular4=26bbd9 # blue
 regular5=ee64ac # magenta
 regular6=59e1e3 # cyan
 regular7=403c3d # white
-bright0=bdb3b1 # bright black
+bright0=f9cbbe # bright black
 bright1=e95678 # bright red
 bright2=29d398 # bright green
 bright3=fadad1 # bright yellow

--- a/colors/base16-humanoid-dark.ini
+++ b/colors/base16-humanoid-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Humanoid dark 
+# tinted-foot
+# Scheme name: Humanoid dark
 # Scheme author: Thomas (tasmo) Friese
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=f8f8f2
 background=232629
@@ -16,7 +14,7 @@ regular4=00a6fb # blue
 regular5=f15ee3 # magenta
 regular6=0dd9d6 # cyan
 regular7=f8f8f2 # white
-bright0=60615d # bright black
+bright0=484e54 # bright black
 bright1=f11235 # bright red
 bright2=02d849 # bright green
 bright3=ffb627 # bright yellow

--- a/colors/base16-humanoid-light.ini
+++ b/colors/base16-humanoid-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Humanoid light 
+# tinted-foot
+# Scheme name: Humanoid light
 # Scheme author: Thomas (tasmo) Friese
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=232629
 background=f8f8f2
@@ -16,7 +14,7 @@ regular4=0082c9 # blue
 regular5=700f98 # magenta
 regular6=008e8e # cyan
 regular7=232629 # white
-bright0=c0c0bd # bright black
+bright0=deded8 # bright black
 bright1=b0151a # bright red
 bright2=388e3c # bright green
 bright3=ffb627 # bright yellow

--- a/colors/base16-ia-dark.ini
+++ b/colors/base16-ia-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: iA Dark 
+# tinted-foot
+# Scheme name: iA Dark
 # Scheme author: iA Inc. (modified by aramisgithub)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cccccc
 background=1a1a1a
@@ -16,7 +14,7 @@ regular4=8eccdd # blue
 regular5=b98eb2 # magenta
 regular6=7c9cae # cyan
 regular7=cccccc # white
-bright0=767676 # bright black
+bright0=1d414d # bright black
 bright1=d88568 # bright red
 bright2=83a471 # bright green
 bright3=b99353 # bright yellow

--- a/colors/base16-ia-light.ini
+++ b/colors/base16-ia-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: iA Light 
+# tinted-foot
+# Scheme name: iA Light
 # Scheme author: iA Inc. (modified by aramisgithub)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=181818
 background=f6f6f6
@@ -16,7 +14,7 @@ regular4=48bac2 # blue
 regular5=a94598 # magenta
 regular6=2d6bb1 # cyan
 regular7=181818 # white
-bright0=898989 # bright black
+bright0=bde5f2 # bright black
 bright1=9c5a02 # bright red
 bright2=38781c # bright green
 bright3=c48218 # bright yellow

--- a/colors/base16-icy.ini
+++ b/colors/base16-icy.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Icy Dark 
+# tinted-foot
+# Scheme name: Icy Dark
 # Scheme author: icyphox (https://icyphox.ga)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=095b67
 background=021012
@@ -16,7 +14,7 @@ regular4=00bcd4 # blue
 regular5=00acc1 # magenta
 regular6=26c6da # cyan
 regular7=095b67 # white
-bright0=052e34 # bright black
+bright0=041f23 # bright black
 bright1=16c1d9 # bright red
 bright2=4dd0e1 # bright green
 bright3=80deea # bright yellow

--- a/colors/base16-irblack.ini
+++ b/colors/base16-irblack.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: IR Black 
+# tinted-foot
+# Scheme name: IR Black
 # Scheme author: Timothée Poisot (http://timotheepoisot.fr)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b5b3aa
 background=000000
@@ -16,7 +14,7 @@ regular4=96cbfe # blue
 regular5=ff73fd # magenta
 regular6=c6c5fe # cyan
 regular7=b5b3aa # white
-bright0=6c6c66 # bright black
+bright0=484844 # bright black
 bright1=ff6c60 # bright red
 bright2=a8ff60 # bright green
 bright3=ffffb6 # bright yellow

--- a/colors/base16-isotope.ini
+++ b/colors/base16-isotope.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Isotope 
+# tinted-foot
+# Scheme name: Isotope
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d0d0d0
 background=000000
@@ -16,7 +14,7 @@ regular4=0066ff # blue
 regular5=cc00ff # magenta
 regular6=00ffff # cyan
 regular7=d0d0d0 # white
-bright0=808080 # bright black
+bright0=606060 # bright black
 bright1=ff0000 # bright red
 bright2=33ff00 # bright green
 bright3=ff0099 # bright yellow

--- a/colors/base16-jabuti.ini
+++ b/colors/base16-jabuti.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Jabuti 
+# tinted-foot
+# Scheme name: Jabuti
 # Scheme author: https://github.com/notusknot
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c0cbe3
 background=292a37
@@ -16,7 +14,7 @@ regular4=3fc6de # blue
 regular5=be95ff # magenta
 regular6=ff7eb6 # cyan
 regular7=c0cbe3 # white
-bright0=45475d # bright black
+bright0=3c3e51 # bright black
 bright1=ec6a88 # bright red
 bright2=3fdaa4 # bright green
 bright3=e1c697 # bright yellow

--- a/colors/base16-kanagawa.ini
+++ b/colors/base16-kanagawa.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Kanagawa 
+# tinted-foot
+# Scheme name: Kanagawa
 # Scheme author: Tommaso Laurenzi (https://github.com/rebelot)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=dcd7ba
 background=1f1f28
@@ -16,7 +14,7 @@ regular4=7e9cd8 # blue
 regular5=957fb8 # magenta
 regular6=6a9589 # cyan
 regular7=dcd7ba # white
-bright0=54546d # bright black
+bright0=223249 # bright black
 bright1=c34043 # bright red
 bright2=76946a # bright green
 bright3=c0a36e # bright yellow

--- a/colors/base16-katy.ini
+++ b/colors/base16-katy.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Katy 
+# tinted-foot
+# Scheme name: Katy
 # Scheme author: George Essig (https://github.com/gessig)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=959dcb
 background=292d3e
@@ -16,7 +14,7 @@ regular4=82aaff # blue
 regular5=c792ea # magenta
 regular6=83b7e5 # cyan
 regular7=959dcb # white
-bright0=676e95 # bright black
+bright0=5c598b # bright black
 bright1=6e98e1 # bright red
 bright2=78c06e # bright green
 bright3=e0a557 # bright yellow

--- a/colors/base16-kimber.ini
+++ b/colors/base16-kimber.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Kimber 
+# tinted-foot
+# Scheme name: Kimber
 # Scheme author: Mishka Nguyen (https://github.com/akhsiM)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=dedee7
 background=222222
@@ -16,7 +14,7 @@ regular4=537c9c # blue
 regular5=86cacd # magenta
 regular6=78b4b4 # cyan
 regular7=dedee7 # white
-bright0=644646 # bright black
+bright0=555d55 # bright black
 bright1=c88c8c # bright red
 bright2=99c899 # bright green
 bright3=d8b56d # bright yellow

--- a/colors/base16-lime.ini
+++ b/colors/base16-lime.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: lime 
+# tinted-foot
+# Scheme name: lime
 # Scheme author: limelier
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=818175
 background=1a1a2f
@@ -16,7 +14,7 @@ regular4=2b926f # blue
 regular5=1b825f # magenta
 regular6=4cad83 # cyan
 regular7=818175 # white
-bright0=313140 # bright black
+bright0=2a2a3f # bright black
 bright1=ff662a # bright red
 bright2=8cd97c # bright green
 bright3=ffd15e # bright yellow

--- a/colors/base16-macintosh.ini
+++ b/colors/base16-macintosh.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Macintosh 
+# tinted-foot
+# Scheme name: Macintosh
 # Scheme author: Rebecca Bettencourt (http://www.kreativekorp.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c0c0c0
 background=000000
@@ -16,7 +14,7 @@ regular4=0000d3 # blue
 regular5=4700a5 # magenta
 regular6=02abea # cyan
 regular7=c0c0c0 # white
-bright0=808080 # bright black
+bright0=404040 # bright black
 bright1=dd0907 # bright red
 bright2=1fb714 # bright green
 bright3=fbf305 # bright yellow

--- a/colors/base16-marrakesh.ini
+++ b/colors/base16-marrakesh.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Marrakesh 
+# tinted-foot
+# Scheme name: Marrakesh
 # Scheme author: Alexandre Gavioli (http://github.com/Alexx2/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=948e48
 background=201602
@@ -16,7 +14,7 @@ regular4=477ca1 # blue
 regular5=8868b3 # magenta
 regular6=75a738 # cyan
 regular7=948e48 # white
-bright0=6c6823 # bright black
+bright0=5f5b17 # bright black
 bright1=c35359 # bright red
 bright2=18974e # bright green
 bright3=a88339 # bright yellow

--- a/colors/base16-materia.ini
+++ b/colors/base16-materia.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Materia 
+# tinted-foot
+# Scheme name: Materia
 # Scheme author: Defman21
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cdd3de
 background=263238
@@ -16,7 +14,7 @@ regular4=89ddff # blue
 regular5=82aaff # magenta
 regular6=80cbc4 # cyan
 regular7=cdd3de # white
-bright0=707880 # bright black
+bright0=37474f # bright black
 bright1=ec5f67 # bright red
 bright2=8bd649 # bright green
 bright3=ffcc00 # bright yellow

--- a/colors/base16-material-darker.ini
+++ b/colors/base16-material-darker.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Material Darker 
+# tinted-foot
+# Scheme name: Material Darker
 # Scheme author: Nate Peterson
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=eeffff
 background=212121
@@ -16,7 +14,7 @@ regular4=82aaff # blue
 regular5=c792ea # magenta
 regular6=89ddff # cyan
 regular7=eeffff # white
-bright0=4a4a4a # bright black
+bright0=353535 # bright black
 bright1=f07178 # bright red
 bright2=c3e88d # bright green
 bright3=ffcb6b # bright yellow

--- a/colors/base16-material-lighter.ini
+++ b/colors/base16-material-lighter.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Material Lighter 
+# tinted-foot
+# Scheme name: Material Lighter
 # Scheme author: Nate Peterson
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=80cbc4
 background=fafafa
@@ -16,7 +14,7 @@ regular4=6182b8 # blue
 regular5=7c4dff # magenta
 regular6=39adb5 # cyan
 regular7=80cbc4 # white
-bright0=ccd7da # bright black
+bright0=cceae7 # bright black
 bright1=ff5370 # bright red
 bright2=91b859 # bright green
 bright3=ffb62c # bright yellow

--- a/colors/base16-material-palenight.ini
+++ b/colors/base16-material-palenight.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Material Palenight 
+# tinted-foot
+# Scheme name: Material Palenight
 # Scheme author: Nate Peterson
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=959dcb
 background=292d3e
@@ -16,7 +14,7 @@ regular4=82aaff # blue
 regular5=c792ea # magenta
 regular6=89ddff # cyan
 regular7=959dcb # white
-bright0=676e95 # bright black
+bright0=32374d # bright black
 bright1=f07178 # bright red
 bright2=c3e88d # bright green
 bright3=ffcb6b # bright yellow

--- a/colors/base16-material-vivid.ini
+++ b/colors/base16-material-vivid.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Material Vivid 
+# tinted-foot
+# Scheme name: Material Vivid
 # Scheme author: joshyrobot
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=80868b
 background=202124
@@ -16,7 +14,7 @@ regular4=2196f3 # blue
 regular5=673ab7 # magenta
 regular6=00bcd4 # cyan
 regular7=80868b # white
-bright0=44464d # bright black
+bright0=323639 # bright black
 bright1=f44336 # bright red
 bright2=00e676 # bright green
 bright3=ffeb3b # bright yellow

--- a/colors/base16-material.ini
+++ b/colors/base16-material.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Material 
+# tinted-foot
+# Scheme name: Material
 # Scheme author: Nate Peterson
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=eeffff
 background=263238
@@ -16,7 +14,7 @@ regular4=82aaff # blue
 regular5=c792ea # magenta
 regular6=89ddff # cyan
 regular7=eeffff # white
-bright0=546e7a # bright black
+bright0=314549 # bright black
 bright1=f07178 # bright red
 bright2=c3e88d # bright green
 bright3=ffcb6b # bright yellow

--- a/colors/base16-measured-dark.ini
+++ b/colors/base16-measured-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Measured Dark 
+# tinted-foot
+# Scheme name: Measured Dark
 # Scheme author: Measured (https://measured.co)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=dcdcdc
 background=00211f
@@ -16,7 +14,7 @@ regular4=88b0da # blue
 regular5=b39be0 # magenta
 regular6=62c0be # cyan
 regular7=dcdcdc # white
-bright0=ababab # bright black
+bright0=005453 # bright black
 bright1=ce7e8e # bright red
 bright2=56c16f # bright green
 bright3=bfac4e # bright yellow

--- a/colors/base16-measured-light.ini
+++ b/colors/base16-measured-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Measured Light 
+# tinted-foot
+# Scheme name: Measured Light
 # Scheme author: Measured (https://measured.co)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=292929
 background=fdf9f5
@@ -16,7 +14,7 @@ regular4=0158ad # blue
 regular5=6645c2 # magenta
 regular6=01716f # cyan
 regular7=292929 # white
-bright0=5a5a5a # bright black
+bright0=ffeada # bright black
 bright1=ac1f35 # bright red
 bright2=0c680c # bright green
 bright3=645a00 # bright yellow

--- a/colors/base16-mellow-purple.ini
+++ b/colors/base16-mellow-purple.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Mellow Purple 
+# tinted-foot
+# Scheme name: Mellow Purple
 # Scheme author: gidsi
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ffeeff
 background=1e0528
@@ -16,7 +14,7 @@ regular4=550068 # blue
 regular5=8991bb # magenta
 regular6=b900b1 # cyan
 regular7=ffeeff # white
-bright0=320f55 # bright black
+bright0=331354 # bright black
 bright1=00d9e9 # bright red
 bright2=05cb0d # bright green
 bright3=955ae7 # bright yellow

--- a/colors/base16-mexico-light.ini
+++ b/colors/base16-mexico-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Mexico Light 
+# tinted-foot
+# Scheme name: Mexico Light
 # Scheme author: Sheldon Johnson
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=383838
 background=f8f8f8
@@ -16,7 +14,7 @@ regular4=7cafc2 # blue
 regular5=96609e # magenta
 regular6=4b8093 # cyan
 regular7=383838 # white
-bright0=b8b8b8 # bright black
+bright0=d8d8d8 # bright black
 bright1=ab4642 # bright red
 bright2=538947 # bright green
 bright3=f79a0e # bright yellow

--- a/colors/base16-mocha.ini
+++ b/colors/base16-mocha.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Mocha 
+# tinted-foot
+# Scheme name: Mocha
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d0c8c6
 background=3b3228
@@ -16,7 +14,7 @@ regular4=8ab3b5 # blue
 regular5=a89bb9 # magenta
 regular6=7bbda4 # cyan
 regular7=d0c8c6 # white
-bright0=7e705a # bright black
+bright0=645240 # bright black
 bright1=cb6077 # bright red
 bright2=beb55b # bright green
 bright3=f4bc87 # bright yellow

--- a/colors/base16-monokai.ini
+++ b/colors/base16-monokai.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Monokai 
+# tinted-foot
+# Scheme name: Monokai
 # Scheme author: Wimer Hazenberg (http://www.monokai.nl)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=f8f8f2
 background=272822
@@ -16,7 +14,7 @@ regular4=66d9ef # blue
 regular5=ae81ff # magenta
 regular6=a1efe4 # cyan
 regular7=f8f8f2 # white
-bright0=75715e # bright black
+bright0=49483e # bright black
 bright1=f92672 # bright red
 bright2=a6e22e # bright green
 bright3=f4bf75 # bright yellow

--- a/colors/base16-moonlight.ini
+++ b/colors/base16-moonlight.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Moonlight 
+# tinted-foot
+# Scheme name: Moonlight
 # Scheme author: Jeremy Swinarton (https://github.com/jswinarton)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a3ace1
 background=212337
@@ -16,7 +14,7 @@ regular4=40ffff # blue
 regular5=b994f1 # magenta
 regular6=04d1f9 # cyan
 regular7=a3ace1 # white
-bright0=748cd6 # bright black
+bright0=596399 # bright black
 bright1=ff5370 # bright red
 bright2=2df4c0 # bright green
 bright3=ffc777 # bright yellow

--- a/colors/base16-mountain.ini
+++ b/colors/base16-mountain.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Mountain 
+# tinted-foot
+# Scheme name: Mountain
 # Scheme author: gnsfujiwara (https://github.com/gnsfujiwara)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cacaca
 background=0f0f0f
@@ -16,7 +14,7 @@ regular4=8f8aac # blue
 regular5=ac8aac # magenta
 regular6=8aabac # cyan
 regular7=cacaca # white
-bright0=4c4c4c # bright black
+bright0=262626 # bright black
 bright1=ac8a8c # bright red
 bright2=8aac8b # bright green
 bright3=aca98a # bright yellow

--- a/colors/base16-nebula.ini
+++ b/colors/base16-nebula.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Nebula 
+# tinted-foot
+# Scheme name: Nebula
 # Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a4a6a9
 background=22273b
@@ -16,7 +14,7 @@ regular4=4d6bb6 # blue
 regular5=716cae # magenta
 regular6=226f68 # cyan
 regular7=a4a6a9 # white
-bright0=6e6f72 # bright black
+bright0=5a8380 # bright black
 bright1=777abc # bright red
 bright2=6562a8 # bright green
 bright3=4f9062 # bright yellow

--- a/colors/base16-nord-light.ini
+++ b/colors/base16-nord-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Nord Light 
+# tinted-foot
+# Scheme name: Nord Light
 # Scheme author: threddast, based on fuxialexander&#39;s doom-nord-light-theme (Doom Emacs)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=2e3440
 background=e5e9f0
@@ -16,7 +14,7 @@ regular4=3b6ea8 # blue
 regular5=97365b # magenta
 regular6=398eac # cyan
 regular7=2e3440 # white
-bright0=aebacf # bright black
+bright0=b8c5db # bright black
 bright1=99324b # bright red
 bright2=4f894c # bright green
 bright3=9a7500 # bright yellow

--- a/colors/base16-nord.ini
+++ b/colors/base16-nord.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Nord 
+# tinted-foot
+# Scheme name: Nord
 # Scheme author: arcticicestudio
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e5e9f0
 background=2e3440
@@ -16,7 +14,7 @@ regular4=81a1c1 # blue
 regular5=b48ead # magenta
 regular6=88c0d0 # cyan
 regular7=e5e9f0 # white
-bright0=4c566a # bright black
+bright0=434c5e # bright black
 bright1=bf616a # bright red
 bright2=a3be8c # bright green
 bright3=ebcb8b # bright yellow

--- a/colors/base16-nova.ini
+++ b/colors/base16-nova.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Nova 
+# tinted-foot
+# Scheme name: Nova
 # Scheme author: George Essig (https://github.com/gessig), Trevor D. Miller (https://trevordmiller.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c5d4dd
 background=3c4c55
@@ -16,7 +14,7 @@ regular4=83afe5 # blue
 regular5=9a93e1 # magenta
 regular6=f2c38f # cyan
 regular7=c5d4dd # white
-bright0=899ba6 # bright black
+bright0=6a7d89 # bright black
 bright1=83afe5 # bright red
 bright2=7fc1ca # bright green
 bright3=a8ce93 # bright yellow

--- a/colors/base16-ocean.ini
+++ b/colors/base16-ocean.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Ocean 
+# tinted-foot
+# Scheme name: Ocean
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c0c5ce
 background=2b303b
@@ -16,7 +14,7 @@ regular4=8fa1b3 # blue
 regular5=b48ead # magenta
 regular6=96b5b4 # cyan
 regular7=c0c5ce # white
-bright0=65737e # bright black
+bright0=4f5b66 # bright black
 bright1=bf616a # bright red
 bright2=a3be8c # bright green
 bright3=ebcb8b # bright yellow

--- a/colors/base16-oceanicnext.ini
+++ b/colors/base16-oceanicnext.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: OceanicNext 
+# tinted-foot
+# Scheme name: OceanicNext
 # Scheme author: https://github.com/voronianski/oceanic-next-color-scheme
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c0c5ce
 background=1b2b34
@@ -16,7 +14,7 @@ regular4=6699cc # blue
 regular5=c594c5 # magenta
 regular6=5fb3b3 # cyan
 regular7=c0c5ce # white
-bright0=65737e # bright black
+bright0=4f5b66 # bright black
 bright1=ec5f67 # bright red
 bright2=99c794 # bright green
 bright3=fac863 # bright yellow

--- a/colors/base16-one-light.ini
+++ b/colors/base16-one-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: One Light 
+# tinted-foot
+# Scheme name: One Light
 # Scheme author: Daniel Pfeifer (http://github.com/purpleKarrot)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=383a42
 background=fafafa
@@ -16,7 +14,7 @@ regular4=4078f2 # blue
 regular5=a626a4 # magenta
 regular6=0184bc # cyan
 regular7=383a42 # white
-bright0=a0a1a7 # bright black
+bright0=e5e5e6 # bright black
 bright1=ca1243 # bright red
 bright2=50a14f # bright green
 bright3=c18401 # bright yellow

--- a/colors/base16-onedark-dark.ini
+++ b/colors/base16-onedark-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: OneDark Dark 
+# tinted-foot
+# Scheme name: OneDark Dark
 # Scheme author: olimorris (https://github.com/olimorris)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=abb2bf
 background=000000
@@ -16,7 +14,7 @@ regular4=61afef # blue
 regular5=d55fde # magenta
 regular6=2bbac5 # cyan
 regular7=abb2bf # white
-bright0=434852 # bright black
+bright0=2c313a # bright black
 bright1=ef596f # bright red
 bright2=89ca78 # bright green
 bright3=e5c07b # bright yellow

--- a/colors/base16-onedark.ini
+++ b/colors/base16-onedark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: OneDark 
+# tinted-foot
+# Scheme name: OneDark
 # Scheme author: Lalit Magant (http://github.com/tilal6991)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=abb2bf
 background=282c34
@@ -16,7 +14,7 @@ regular4=61afef # blue
 regular5=c678dd # magenta
 regular6=56b6c2 # cyan
 regular7=abb2bf # white
-bright0=545862 # bright black
+bright0=3e4451 # bright black
 bright1=e06c75 # bright red
 bright2=98c379 # bright green
 bright3=e5c07b # bright yellow

--- a/colors/base16-outrun-dark.ini
+++ b/colors/base16-outrun-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Outrun Dark 
+# tinted-foot
+# Scheme name: Outrun Dark
 # Scheme author: Hugo Delahousse (http://github.com/hugodelahousse/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d0d0fa
 background=00002a
@@ -16,7 +14,7 @@ regular4=66b0ff # blue
 regular5=f10596 # magenta
 regular6=0ef0f0 # cyan
 regular7=d0d0fa # white
-bright0=50507a # bright black
+bright0=30305a # bright black
 bright1=ff4242 # bright red
 bright2=59f176 # bright green
 bright3=f3e877 # bright yellow

--- a/colors/base16-oxocarbon-dark.ini
+++ b/colors/base16-oxocarbon-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Oxocarbon Dark 
+# tinted-foot
+# Scheme name: Oxocarbon Dark
 # Scheme author: shaunsingh/IBM
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=f2f4f8
 background=161616
@@ -16,7 +14,7 @@ regular4=42be65 # blue
 regular5=be95ff # magenta
 regular6=ff7eb6 # cyan
 regular7=f2f4f8 # white
-bright0=525252 # bright black
+bright0=393939 # bright black
 bright1=3ddbd9 # bright red
 bright2=33b1ff # bright green
 bright3=ee5396 # bright yellow

--- a/colors/base16-oxocarbon-light.ini
+++ b/colors/base16-oxocarbon-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Oxocarbon Light 
+# tinted-foot
+# Scheme name: Oxocarbon Light
 # Scheme author: shaunsingh/IBM
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=393939
 background=f2f4f8
@@ -16,7 +14,7 @@ regular4=42be65 # blue
 regular5=be95ff # magenta
 regular6=673ab7 # cyan
 regular7=393939 # white
-bright0=161616 # bright black
+bright0=525252 # bright black
 bright1=ff7eb6 # bright red
 bright2=0f62fe # bright green
 bright3=ff6f00 # bright yellow

--- a/colors/base16-pandora.ini
+++ b/colors/base16-pandora.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: pandora 
+# tinted-foot
+# Scheme name: pandora
 # Scheme author: Cassandra Fox
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=f15c99
 background=131213
@@ -16,7 +14,7 @@ regular4=008080 # blue
 regular5=a24030 # magenta
 regular6=714ca6 # cyan
 regular7=f15c99 # white
-bright0=ffbee3 # bright black
+bright0=472234 # bright black
 bright1=b00b69 # bright red
 bright2=9ddf69 # bright green
 bright3=ffcc00 # bright yellow

--- a/colors/base16-papercolor-dark.ini
+++ b/colors/base16-papercolor-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: PaperColor Dark 
+# tinted-foot
+# Scheme name: PaperColor Dark
 # Scheme author: Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=808080
 background=1c1c1c
@@ -16,7 +14,7 @@ regular4=ff5faf # blue
 regular5=00afaf # magenta
 regular6=ffaf00 # cyan
 regular7=808080 # white
-bright0=d7af5f # bright black
+bright0=5faf00 # bright black
 bright1=585858 # bright red
 bright2=af87d7 # bright green
 bright3=afd700 # bright yellow

--- a/colors/base16-papercolor-light.ini
+++ b/colors/base16-papercolor-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: PaperColor Light 
+# tinted-foot
+# Scheme name: PaperColor Light
 # Scheme author: Jon Leopard (http://github.com/jonleopard), based on PaperColor Theme (https://github.com/NLKNguyen/papercolor-theme)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=444444
 background=eeeeee
@@ -16,7 +14,7 @@ regular4=d75f00 # blue
 regular5=005faf # magenta
 regular6=d75f00 # cyan
 regular7=444444 # white
-bright0=5f8700 # bright black
+bright0=008700 # bright black
 bright1=bcbcbc # bright red
 bright2=8700af # bright green
 bright3=d70087 # bright yellow

--- a/colors/base16-paraiso.ini
+++ b/colors/base16-paraiso.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Paraiso 
+# tinted-foot
+# Scheme name: Paraiso
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a39e9b
 background=2f1e2e
@@ -16,7 +14,7 @@ regular4=06b6ef # blue
 regular5=815ba4 # magenta
 regular6=5bc4bf # cyan
 regular7=a39e9b # white
-bright0=776e71 # bright black
+bright0=4f424c # bright black
 bright1=ef6155 # bright red
 bright2=48b685 # bright green
 bright3=fec418 # bright yellow

--- a/colors/base16-pasque.ini
+++ b/colors/base16-pasque.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Pasque 
+# tinted-foot
+# Scheme name: Pasque
 # Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=dedcdf
 background=271c3a
@@ -16,7 +14,7 @@ regular4=8e7dc6 # blue
 regular5=953b9d # magenta
 regular6=7263aa # cyan
 regular7=dedcdf # white
-bright0=5d5766 # bright black
+bright0=3e2d5c # bright black
 bright1=a92258 # bright red
 bright2=c6914b # bright green
 bright3=804ead # bright yellow

--- a/colors/base16-phd.ini
+++ b/colors/base16-phd.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: PhD 
+# tinted-foot
+# Scheme name: PhD
 # Scheme author: Hennig Hasemann (http://leetless.de/vim.html)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b8bbc2
 background=061229
@@ -16,7 +14,7 @@ regular4=5299bf # blue
 regular5=9989cc # magenta
 regular6=72b9bf # cyan
 regular7=b8bbc2 # white
-bright0=717885 # bright black
+bright0=4d5666 # bright black
 bright1=d07346 # bright red
 bright2=99bf52 # bright green
 bright3=fbd461 # bright yellow

--- a/colors/base16-pico.ini
+++ b/colors/base16-pico.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Pico 
+# tinted-foot
+# Scheme name: Pico
 # Scheme author: PICO-8 (http://www.lexaloffle.com/pico-8.php)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5f574f
 background=000000
@@ -16,7 +14,7 @@ regular4=83769c # blue
 regular5=ff77a8 # magenta
 regular6=29adff # cyan
 regular7=5f574f # white
-bright0=008751 # bright black
+bright0=7e2553 # bright black
 bright1=ff004d # bright red
 bright2=00e756 # bright green
 bright3=fff024 # bright yellow

--- a/colors/base16-pinky.ini
+++ b/colors/base16-pinky.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: pinky 
+# tinted-foot
+# Scheme name: pinky
 # Scheme author: Benjamin (https://github.com/b3nj5m1n)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=f5f5f5
 background=171517
@@ -16,7 +14,7 @@ regular4=00ffff # blue
 regular5=007fff # magenta
 regular6=6600ff # cyan
 regular7=f5f5f5 # white
-bright0=383338 # bright black
+bright0=1d1b1d # bright black
 bright1=ffa600 # bright red
 bright2=ff0066 # bright green
 bright3=20df6c # bright yellow

--- a/colors/base16-pop.ini
+++ b/colors/base16-pop.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Pop 
+# tinted-foot
+# Scheme name: Pop
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d0d0d0
 background=000000
@@ -16,7 +14,7 @@ regular4=0e5a94 # blue
 regular5=b31e8d # magenta
 regular6=00aabb # cyan
 regular7=d0d0d0 # white
-bright0=505050 # bright black
+bright0=303030 # bright black
 bright1=eb008a # bright red
 bright2=37b349 # bright green
 bright3=f8ca12 # bright yellow

--- a/colors/base16-porple.ini
+++ b/colors/base16-porple.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Porple 
+# tinted-foot
+# Scheme name: Porple
 # Scheme author: Niek den Breeje (https://github.com/AuditeMarlow)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d8d8d8
 background=292c36
@@ -16,7 +14,7 @@ regular4=8485ce # blue
 regular5=b74989 # magenta
 regular6=64878f # cyan
 regular7=d8d8d8 # white
-bright0=65568a # bright black
+bright0=474160 # bright black
 bright1=f84547 # bright red
 bright2=95c76f # bright green
 bright3=efa16b # bright yellow

--- a/colors/base16-precious-dark-eleven.ini
+++ b/colors/base16-precious-dark-eleven.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Precious Dark Eleven 
+# tinted-foot
+# Scheme name: Precious Dark Eleven
 # Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b8b7b6
 background=1c1e20
@@ -16,7 +14,7 @@ regular4=68b0ee # blue
 regular5=b799fe # magenta
 regular6=42bda7 # cyan
 regular7=b8b7b6 # white
-bright0=858585 # bright black
+bright0=37393a # bright black
 bright1=ff8782 # bright red
 bright2=95b658 # bright green
 bright3=d0a543 # bright yellow

--- a/colors/base16-precious-dark-fifteen.ini
+++ b/colors/base16-precious-dark-fifteen.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Precious Dark Fifteen 
+# tinted-foot
+# Scheme name: Precious Dark Fifteen
 # Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=bab9b6
 background=23262b
@@ -16,7 +14,7 @@ regular4=66b0ef # blue
 regular5=b799ff # magenta
 regular6=42bda7 # cyan
 regular7=bab9b6 # white
-bright0=898989 # bright black
+bright0=3e4044 # bright black
 bright1=ff8782 # bright red
 bright2=95b659 # bright green
 bright3=cfa546 # bright yellow

--- a/colors/base16-precious-light-warm.ini
+++ b/colors/base16-precious-light-warm.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Precious Light Warm 
+# tinted-foot
+# Scheme name: Precious Light Warm
 # Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=4e5359
 background=fff5e5
@@ -16,7 +14,7 @@ regular4=246da5 # blue
 regular5=7a50c6 # magenta
 regular6=0e7767 # cyan
 regular7=4e5359 # white
-bright0=7f8080 # bright black
+bright0=d9d3c8 # bright black
 bright1=b14745 # bright red
 bright2=557300 # bright green
 bright3=876500 # bright yellow

--- a/colors/base16-precious-light-white.ini
+++ b/colors/base16-precious-light-white.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Precious Light White 
+# tinted-foot
+# Scheme name: Precious Light White
 # Scheme author: 4lex4 &lt;4lex49@zoho.com&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=555555
 background=ffffff
@@ -16,7 +14,7 @@ regular4=186daa # blue
 regular5=7b4ecb # magenta
 regular6=087767 # cyan
 regular7=555555 # white
-bright0=848484 # bright black
+bright0=dbdbdb # bright black
 bright1=af4947 # bright red
 bright2=557301 # bright green
 bright3=876500 # bright yellow

--- a/colors/base16-primer-dark-dimmed.ini
+++ b/colors/base16-primer-dark-dimmed.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Primer Dark Dimmed 
+# tinted-foot
+# Scheme name: Primer Dark Dimmed
 # Scheme author: Jimmy Lin
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=909dab
 background=1c2128
@@ -16,7 +14,7 @@ regular4=539bf5 # blue
 regular5=e275ad # magenta
 regular6=96d0ff # cyan
 regular7=909dab # white
-bright0=545d68 # bright black
+bright0=444c56 # bright black
 bright1=f47067 # bright red
 bright2=57ab5a # bright green
 bright3=c69026 # bright yellow

--- a/colors/base16-primer-dark.ini
+++ b/colors/base16-primer-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Primer Dark 
+# tinted-foot
+# Scheme name: Primer Dark
 # Scheme author: Jimmy Lin
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b1bac4
 background=010409
@@ -16,7 +14,7 @@ regular4=58a6ff # blue
 regular5=f778ba # magenta
 regular6=a5d6ff # cyan
 regular7=b1bac4 # white
-bright0=484f58 # bright black
+bright0=30363d # bright black
 bright1=ff7b72 # bright red
 bright2=3fb950 # bright green
 bright3=d29922 # bright yellow

--- a/colors/base16-primer-light.ini
+++ b/colors/base16-primer-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Primer Light 
+# tinted-foot
+# Scheme name: Primer Light
 # Scheme author: Jimmy Lin
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=2f363d
 background=fafbfc
@@ -16,7 +14,7 @@ regular4=0366d6 # blue
 regular5=ea4aaa # magenta
 regular6=79b8ff # cyan
 regular7=2f363d # white
-bright0=959da5 # bright black
+bright0=d1d5da # bright black
 bright1=d73a49 # bright red
 bright2=28a745 # bright green
 bright3=ffd33d # bright yellow

--- a/colors/base16-purpledream.ini
+++ b/colors/base16-purpledream.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Purpledream 
+# tinted-foot
+# Scheme name: Purpledream
 # Scheme author: malet
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ddd0dd
 background=100510
@@ -16,7 +14,7 @@ regular4=00a0f0 # blue
 regular5=b000d0 # magenta
 regular6=0075b0 # cyan
 regular7=ddd0dd # white
-bright0=605060 # bright black
+bright0=403040 # bright black
 bright1=ff1d0d # bright red
 bright2=14cc64 # bright green
 bright3=f000a0 # bright yellow

--- a/colors/base16-qualia.ini
+++ b/colors/base16-qualia.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Qualia 
+# tinted-foot
+# Scheme name: Qualia
 # Scheme author: isaacwhanson
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c0c0c0
 background=101010

--- a/colors/base16-railscasts.ini
+++ b/colors/base16-railscasts.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Railscasts 
+# tinted-foot
+# Scheme name: Railscasts
 # Scheme author: Ryan Bates (http://railscasts.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e6e1dc
 background=2b2b2b
@@ -16,7 +14,7 @@ regular4=6d9cbe # blue
 regular5=b6b3eb # magenta
 regular6=519f50 # cyan
 regular7=e6e1dc # white
-bright0=5a647e # bright black
+bright0=3a4055 # bright black
 bright1=da4939 # bright red
 bright2=a5c261 # bright green
 bright3=ffc66d # bright yellow

--- a/colors/base16-rebecca.ini
+++ b/colors/base16-rebecca.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Rebecca 
+# tinted-foot
+# Scheme name: Rebecca
 # Scheme author: Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=f1eff8
 background=292a44
@@ -16,7 +14,7 @@ regular4=2de0a7 # blue
 regular5=7aa5ff # magenta
 regular6=8eaee0 # cyan
 regular7=f1eff8 # white
-bright0=666699 # bright black
+bright0=383a62 # bright black
 bright1=a0a0c5 # bright red
 bright2=6dfedf # bright green
 bright3=ae81ff # bright yellow

--- a/colors/base16-rose-pine-dawn.ini
+++ b/colors/base16-rose-pine-dawn.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Rosé Pine Dawn 
+# tinted-foot
+# Scheme name: Rosé Pine Dawn
 # Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=575279
 background=faf4ed
@@ -16,7 +14,7 @@ regular4=907aa9 # blue
 regular5=ea9d34 # magenta
 regular6=56949f # cyan
 regular7=575279 # white
-bright0=9893a5 # bright black
+bright0=f2e9de # bright black
 bright1=b4637a # bright red
 bright2=286983 # bright green
 bright3=d7827e # bright yellow

--- a/colors/base16-rose-pine-moon.ini
+++ b/colors/base16-rose-pine-moon.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Rosé Pine Moon 
+# tinted-foot
+# Scheme name: Rosé Pine Moon
 # Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e0def4
 background=232136
@@ -16,7 +14,7 @@ regular4=c4a7e7 # blue
 regular5=f6c177 # magenta
 regular6=9ccfd8 # cyan
 regular7=e0def4 # white
-bright0=6e6a86 # bright black
+bright0=393552 # bright black
 bright1=eb6f92 # bright red
 bright2=3e8fb0 # bright green
 bright3=ea9a97 # bright yellow

--- a/colors/base16-rose-pine.ini
+++ b/colors/base16-rose-pine.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Rosé Pine 
+# tinted-foot
+# Scheme name: Rosé Pine
 # Scheme author: Emilia Dunfelt &lt;edun@dunfelt.se&gt;
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e0def4
 background=191724
@@ -16,7 +14,7 @@ regular4=c4a7e7 # blue
 regular5=f6c177 # magenta
 regular6=9ccfd8 # cyan
 regular7=e0def4 # white
-bright0=6e6a86 # bright black
+bright0=26233a # bright black
 bright1=eb6f92 # bright red
 bright2=31748f # bright green
 bright3=ebbcba # bright yellow

--- a/colors/base16-saga.ini
+++ b/colors/base16-saga.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: SAGA 
+# tinted-foot
+# Scheme name: SAGA
 # Scheme author: https://github.com/SAGAtheme/SAGA
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=dce2f7
 background=05080a
@@ -16,7 +14,7 @@ regular4=c9fff7 # blue
 regular5=dcc3f9 # magenta
 regular6=c5edc1 # cyan
 regular7=dce2f7 # white
-bright0=141f27 # bright black
+bright0=0f181e # bright black
 bright1=ffd4e9 # bright red
 bright2=f7ddff # bright green
 bright3=fbebc8 # bright yellow

--- a/colors/base16-sagelight.ini
+++ b/colors/base16-sagelight.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Sagelight 
+# tinted-foot
+# Scheme name: Sagelight
 # Scheme author: Carter Veldhuizen
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=383838
 background=f8f8f8
@@ -16,7 +14,7 @@ regular4=a0a7d2 # blue
 regular5=c8a0d2 # magenta
 regular6=a2d6f5 # cyan
 regular7=383838 # white
-bright0=b8b8b8 # bright black
+bright0=d8d8d8 # bright black
 bright1=fa8480 # bright red
 bright2=a0d2c8 # bright green
 bright3=ffdc61 # bright yellow

--- a/colors/base16-sakura.ini
+++ b/colors/base16-sakura.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Sakura 
+# tinted-foot
+# Scheme name: Sakura
 # Scheme author: Misterio77 (http://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=564448
 background=feedf3
@@ -16,7 +14,7 @@ regular4=006e93 # blue
 regular5=5e2180 # magenta
 regular6=1d8991 # cyan
 regular7=564448 # white
-bright0=755f64 # bright black
+bright0=e0ccd1 # bright black
 bright1=df2d52 # bright red
 bright2=2e916d # bright green
 bright3=c29461 # bright yellow

--- a/colors/base16-sandcastle.ini
+++ b/colors/base16-sandcastle.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Sandcastle 
+# tinted-foot
+# Scheme name: Sandcastle
 # Scheme author: George Essig (https://github.com/gessig)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a89984
 background=282c34
@@ -16,7 +14,7 @@ regular4=83a598 # blue
 regular5=d75f5f # magenta
 regular6=83a598 # cyan
 regular7=a89984 # white
-bright0=665c54 # bright black
+bright0=3e4451 # bright black
 bright1=83a598 # bright red
 bright2=528b8b # bright green
 bright3=a07e3b # bright yellow

--- a/colors/base16-selenized-black.ini
+++ b/colors/base16-selenized-black.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: selenized-black 
+# tinted-foot
+# Scheme name: selenized-black
 # Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b9b9b9
 background=181818
@@ -16,7 +14,7 @@ regular4=368aeb # blue
 regular5=a580e2 # magenta
 regular6=3fc5b7 # cyan
 regular7=b9b9b9 # white
-bright0=777777 # bright black
+bright0=3b3b3b # bright black
 bright1=ed4a46 # bright red
 bright2=70b433 # bright green
 bright3=dbb32d # bright yellow

--- a/colors/base16-selenized-dark.ini
+++ b/colors/base16-selenized-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: selenized-dark 
+# tinted-foot
+# Scheme name: selenized-dark
 # Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=adbcbc
 background=103c48
@@ -16,7 +14,7 @@ regular4=4695f7 # blue
 regular5=af88eb # magenta
 regular6=41c7b9 # cyan
 regular7=adbcbc # white
-bright0=72898f # bright black
+bright0=2d5b69 # bright black
 bright1=fa5750 # bright red
 bright2=75b938 # bright green
 bright3=dbb32d # bright yellow

--- a/colors/base16-selenized-light.ini
+++ b/colors/base16-selenized-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: selenized-light 
+# tinted-foot
+# Scheme name: selenized-light
 # Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=53676d
 background=fbf3db
@@ -16,7 +14,7 @@ regular4=006dce # blue
 regular5=825dc0 # magenta
 regular6=00978a # cyan
 regular7=53676d # white
-bright0=909995 # bright black
+bright0=d5cdb6 # bright black
 bright1=cc1729 # bright red
 bright2=428b00 # bright green
 bright3=a78300 # bright yellow

--- a/colors/base16-selenized-white.ini
+++ b/colors/base16-selenized-white.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: selenized-white 
+# tinted-foot
+# Scheme name: selenized-white
 # Scheme author: Jan Warchol (https://github.com/jan-warchol/selenized) / adapted to base16 by ali
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=474747
 background=ffffff
@@ -16,7 +14,7 @@ regular4=0054cf # blue
 regular5=6b40c3 # magenta
 regular6=009a8a # cyan
 regular7=474747 # white
-bright0=878787 # bright black
+bright0=cdcdcd # bright black
 bright1=bf0000 # bright red
 bright2=008400 # bright green
 bright3=af8500 # bright yellow

--- a/colors/base16-seti.ini
+++ b/colors/base16-seti.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Seti UI 
+# tinted-foot
+# Scheme name: Seti UI
 # Scheme author: 
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d6d6d6
 background=151718
@@ -16,7 +14,7 @@ regular4=55b5db # blue
 regular5=a074c4 # magenta
 regular6=55dbbe # cyan
 regular7=d6d6d6 # white
-bright0=41535b # bright black
+bright0=3b758c # bright black
 bright1=cd3f45 # bright red
 bright2=9fca56 # bright green
 bright3=e6cd69 # bright yellow

--- a/colors/base16-shades-of-purple.ini
+++ b/colors/base16-shades-of-purple.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Shades of Purple 
+# tinted-foot
+# Scheme name: Shades of Purple
 # Scheme author: Iolar Demartini Junior (http://github.com/demartini), based on Shades of Purple Theme (https://github.com/ahmadawais/shades-of-purple-vscode)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c7c7c7
 background=1e1e3f
@@ -16,7 +14,7 @@ regular4=6943ff # blue
 regular5=ff2c70 # magenta
 regular6=00c5c7 # cyan
 regular7=c7c7c7 # white
-bright0=808080 # bright black
+bright0=f1d000 # bright black
 bright1=d90429 # bright red
 bright2=3ad900 # bright green
 bright3=ffe700 # bright yellow

--- a/colors/base16-shadesmear-dark.ini
+++ b/colors/base16-shadesmear-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: ShadeSmear Dark 
+# tinted-foot
+# Scheme name: ShadeSmear Dark
 # Scheme author: Kyle Giammarco (http://kyle.giammar.co)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=dbdbdb
 background=232323
@@ -16,7 +14,7 @@ regular4=376388 # blue
 regular5=d7ab54 # magenta
 regular6=c57d42 # cyan
 regular7=dbdbdb # white
-bright0=c0c0c0 # bright black
+bright0=4e4e4e # bright black
 bright1=cc5450 # bright red
 bright2=71983b # bright green
 bright3=307878 # bright yellow

--- a/colors/base16-shadesmear-light.ini
+++ b/colors/base16-shadesmear-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: ShadeSmear Light 
+# tinted-foot
+# Scheme name: ShadeSmear Light
 # Scheme author: Kyle Giammarco (http://kyle.giammar.co)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=232323
 background=dbdbdb
@@ -16,7 +14,7 @@ regular4=376388 # blue
 regular5=d7ab54 # magenta
 regular6=c57d42 # cyan
 regular7=232323 # white
-bright0=4e4e4e # bright black
+bright0=c0c0c0 # bright black
 bright1=cc5450 # bright red
 bright2=71983b # bright green
 bright3=307878 # bright yellow

--- a/colors/base16-shapeshifter.ini
+++ b/colors/base16-shapeshifter.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Shapeshifter 
+# tinted-foot
+# Scheme name: Shapeshifter
 # Scheme author: Tyler Benziger (http://tybenz.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=102015
 background=f9f9f9
@@ -16,7 +14,7 @@ regular4=3b48e3 # blue
 regular5=f996e2 # magenta
 regular6=23edda # cyan
 regular7=102015 # white
-bright0=555555 # bright black
+bright0=ababab # bright black
 bright1=e92f2f # bright red
 bright2=0ed839 # bright green
 bright3=dddd13 # bright yellow

--- a/colors/base16-silk-dark.ini
+++ b/colors/base16-silk-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Silk Dark 
+# tinted-foot
+# Scheme name: Silk Dark
 # Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c7dbdd
 background=0e3c46
@@ -16,7 +14,7 @@ regular4=46bddd # blue
 regular5=756b8a # magenta
 regular6=3fb2b9 # cyan
 regular7=c7dbdd # white
-bright0=587073 # bright black
+bright0=2a5054 # bright black
 bright1=fb6953 # bright red
 bright2=73d8ad # bright green
 bright3=fce380 # bright yellow

--- a/colors/base16-silk-light.ini
+++ b/colors/base16-silk-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Silk Light 
+# tinted-foot
+# Scheme name: Silk Light
 # Scheme author: Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=385156
 background=e9f1ef
@@ -16,7 +14,7 @@ regular4=39aac9 # blue
 regular5=6e6582 # magenta
 regular6=329ca2 # cyan
 regular7=385156 # white
-bright0=5c787b # bright black
+bright0=90b7b6 # bright black
 bright1=cf432e # bright red
 bright2=6ca38c # bright green
 bright3=cfad25 # bright yellow

--- a/colors/base16-snazzy.ini
+++ b/colors/base16-snazzy.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Snazzy 
+# tinted-foot
+# Scheme name: Snazzy
 # Scheme author: Chawye Hsu (https://github.com/chawyehsu), based on Hyper Snazzy Theme (https://github.com/sindresorhus/hyper-snazzy)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=e2e4e5
 background=282a36
@@ -16,7 +14,7 @@ regular4=57c7ff # blue
 regular5=ff6ac1 # magenta
 regular6=9aedfe # cyan
 regular7=e2e4e5 # white
-bright0=78787e # bright black
+bright0=43454f # bright black
 bright1=ff5c57 # bright red
 bright2=5af78e # bright green
 bright3=f3f99d # bright yellow

--- a/colors/base16-solarflare-light.ini
+++ b/colors/base16-solarflare-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Solar Flare Light 
+# tinted-foot
+# Scheme name: Solar Flare Light
 # Scheme author: Chuck Harmston (https://chuck.harmston.ch)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=586875
 background=f5f7fa
@@ -16,7 +14,7 @@ regular4=33b5e1 # blue
 regular5=a363d5 # magenta
 regular6=52cbb0 # cyan
 regular7=586875 # white
-bright0=85939e # bright black
+bright0=a6afb8 # bright black
 bright1=ef5253 # bright red
 bright2=7cc844 # bright green
 bright3=e4b51c # bright yellow

--- a/colors/base16-solarflare.ini
+++ b/colors/base16-solarflare.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Solar Flare 
+# tinted-foot
+# Scheme name: Solar Flare
 # Scheme author: Chuck Harmston (https://chuck.harmston.ch)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a6afb8
 background=18262f
@@ -16,7 +14,7 @@ regular4=33b5e1 # blue
 regular5=a363d5 # magenta
 regular6=52cbb0 # cyan
 regular7=a6afb8 # white
-bright0=667581 # bright black
+bright0=586875 # bright black
 bright1=ef5253 # bright red
 bright2=7cc844 # bright green
 bright3=e4b51c # bright yellow

--- a/colors/base16-solarized-dark.ini
+++ b/colors/base16-solarized-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Solarized Dark 
+# tinted-foot
+# Scheme name: Solarized Dark
 # Scheme author: Ethan Schoonover (modified by aramisgithub)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=93a1a1
 background=002b36
@@ -16,7 +14,7 @@ regular4=268bd2 # blue
 regular5=6c71c4 # magenta
 regular6=2aa198 # cyan
 regular7=93a1a1 # white
-bright0=657b83 # bright black
+bright0=586e75 # bright black
 bright1=dc322f # bright red
 bright2=859900 # bright green
 bright3=b58900 # bright yellow

--- a/colors/base16-solarized-light.ini
+++ b/colors/base16-solarized-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Solarized Light 
+# tinted-foot
+# Scheme name: Solarized Light
 # Scheme author: Ethan Schoonover (modified by aramisgithub)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=586e75
 background=fdf6e3
@@ -16,7 +14,7 @@ regular4=268bd2 # blue
 regular5=6c71c4 # magenta
 regular6=2aa198 # cyan
 regular7=586e75 # white
-bright0=839496 # bright black
+bright0=93a1a1 # bright black
 bright1=dc322f # bright red
 bright2=859900 # bright green
 bright3=b58900 # bright yellow

--- a/colors/base16-spaceduck.ini
+++ b/colors/base16-spaceduck.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Spaceduck 
+# tinted-foot
+# Scheme name: Spaceduck
 # Scheme author: Guillermo Rodriguez (https://github.com/pineapplegiant), packaged by Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=ecf0c1
 background=16172d
@@ -16,7 +14,7 @@ regular4=7a5ccc # blue
 regular5=b3a1e6 # magenta
 regular6=00a3cc # cyan
 regular7=ecf0c1 # white
-bright0=686f9a # bright black
+bright0=30365f # bright black
 bright1=e33400 # bright red
 bright2=5ccc96 # bright green
 bright3=f2ce00 # bright yellow

--- a/colors/base16-spacemacs.ini
+++ b/colors/base16-spacemacs.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Spacemacs 
+# tinted-foot
+# Scheme name: Spacemacs
 # Scheme author: Nasser Alshammari (https://github.com/nashamri/spacemacs-theme)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a3a3a3
 background=1f2022
@@ -16,7 +14,7 @@ regular4=4f97d7 # blue
 regular5=a31db1 # magenta
 regular6=2d9574 # cyan
 regular7=a3a3a3 # white
-bright0=585858 # bright black
+bright0=444155 # bright black
 bright1=f2241f # bright red
 bright2=67b11d # bright green
 bright3=b1951d # bright yellow

--- a/colors/base16-sparky.ini
+++ b/colors/base16-sparky.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Sparky 
+# tinted-foot
+# Scheme name: Sparky
 # Scheme author: Leila Sother (https://github.com/mixcoac)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=f4f5f0
 background=072b31
@@ -16,7 +14,7 @@ regular4=4698cb # blue
 regular5=d59ed7 # magenta
 regular6=2dccd3 # cyan
 regular7=f4f5f0 # white
-bright0=003b49 # bright black
+bright0=003c46 # bright black
 bright1=ff585d # bright red
 bright2=78d64b # bright green
 bright3=fbdd40 # bright yellow

--- a/colors/base16-standardized-dark.ini
+++ b/colors/base16-standardized-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: standardized-dark 
+# tinted-foot
+# Scheme name: standardized-dark
 # Scheme author: ali (https://github.com/ali-githb/base16-standardized-scheme)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c0c0c0
 background=222222
@@ -16,7 +14,7 @@ regular4=00a3f2 # blue
 regular5=b46ee0 # magenta
 regular6=21c992 # cyan
 regular7=c0c0c0 # white
-bright0=898989 # bright black
+bright0=555555 # bright black
 bright1=e15d67 # bright red
 bright2=5db129 # bright green
 bright3=e1b31a # bright yellow

--- a/colors/base16-standardized-light.ini
+++ b/colors/base16-standardized-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: standardized-light 
+# tinted-foot
+# Scheme name: standardized-light
 # Scheme author: ali (https://github.com/ali-githb/base16-standardized-scheme)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=444444
 background=ffffff
@@ -16,7 +14,7 @@ regular4=3173c5 # blue
 regular5=9e57c2 # magenta
 regular6=00998f # cyan
 regular7=444444 # white
-bright0=767676 # bright black
+bright0=cccccc # bright black
 bright1=d03e3e # bright red
 bright2=31861f # bright green
 bright3=ad8200 # bright yellow

--- a/colors/base16-stella.ini
+++ b/colors/base16-stella.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Stella 
+# tinted-foot
+# Scheme name: Stella
 # Scheme author: Shrimpram
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=998bad
 background=2b213c
@@ -16,7 +14,7 @@ regular4=a5aad4 # blue
 regular5=c594ff # magenta
 regular6=9bc7bf # cyan
 regular7=998bad # white
-bright0=655978 # bright black
+bright0=4d4160 # bright black
 bright1=c79987 # bright red
 bright2=acc79b # bright green
 bright3=c7c691 # bright yellow

--- a/colors/base16-still-alive.ini
+++ b/colors/base16-still-alive.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Still Alive 
+# tinted-foot
+# Scheme name: Still Alive
 # Scheme author: Derrick McKee (derrick.mckee@gmail.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d80000
 background=f0f0f0
@@ -16,7 +14,7 @@ regular4=001878 # blue
 regular5=900000 # magenta
 regular6=2c3c57 # cyan
 regular7=d80000 # white
-bright0=f01818 # bright black
+bright0=fff018 # bright black
 bright1=487830 # bright red
 bright2=5c5c6a # bright green
 bright3=426395 # bright yellow

--- a/colors/base16-summercamp.ini
+++ b/colors/base16-summercamp.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: summercamp 
+# tinted-foot
+# Scheme name: summercamp
 # Scheme author: zoe firi (zoefiri.github.io)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=736e55
 background=1c1810
@@ -16,7 +14,7 @@ regular4=489bf0 # blue
 regular5=ff8080 # magenta
 regular6=5aebbc # cyan
 regular7=736e55 # white
-bright0=504b38 # bright black
+bright0=3a3527 # bright black
 bright1=e35142 # bright red
 bright2=5ceb5a # bright green
 bright3=f2ff27 # bright yellow

--- a/colors/base16-summerfruit-dark.ini
+++ b/colors/base16-summerfruit-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Summerfruit Dark 
+# tinted-foot
+# Scheme name: Summerfruit Dark
 # Scheme author: Christopher Corley (http://christop.club/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d0d0d0
 background=151515
@@ -16,7 +14,7 @@ regular4=3777e6 # blue
 regular5=ad00a1 # magenta
 regular6=1faaaa # cyan
 regular7=d0d0d0 # white
-bright0=505050 # bright black
+bright0=303030 # bright black
 bright1=ff0086 # bright red
 bright2=00c918 # bright green
 bright3=aba800 # bright yellow

--- a/colors/base16-summerfruit-light.ini
+++ b/colors/base16-summerfruit-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Summerfruit Light 
+# tinted-foot
+# Scheme name: Summerfruit Light
 # Scheme author: Christopher Corley (http://christop.club/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=101010
 background=ffffff
@@ -16,7 +14,7 @@ regular4=3777e6 # blue
 regular5=ad00a1 # magenta
 regular6=1faaaa # cyan
 regular7=101010 # white
-bright0=b0b0b0 # bright black
+bright0=d0d0d0 # bright black
 bright1=ff0086 # bright red
 bright2=00c918 # bright green
 bright3=aba800 # bright yellow

--- a/colors/base16-synth-midnight-dark.ini
+++ b/colors/base16-synth-midnight-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Synth Midnight Terminal Dark 
+# tinted-foot
+# Scheme name: Synth Midnight Terminal Dark
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c1c3c4
 background=050608
@@ -16,7 +14,7 @@ regular4=03aeff # blue
 regular5=ea5ce2 # magenta
 regular6=42fff9 # cyan
 regular7=c1c3c4 # white
-bright0=474849 # bright black
+bright0=28292a # bright black
 bright1=b53b50 # bright red
 bright2=06ea61 # bright green
 bright3=c9d364 # bright yellow

--- a/colors/base16-synth-midnight-light.ini
+++ b/colors/base16-synth-midnight-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Synth Midnight Terminal Light 
+# tinted-foot
+# Scheme name: Synth Midnight Terminal Light
 # Scheme author: Michaël Ball (http://github.com/michael-ball/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=28292a
 background=dddfe0
@@ -16,7 +14,7 @@ regular4=03aeff # blue
 regular5=ea5ce2 # magenta
 regular6=42fff9 # cyan
 regular7=28292a # white
-bright0=a3a5a6 # bright black
+bright0=c1c3c4 # bright black
 bright1=b53b50 # bright red
 bright2=06ea61 # bright green
 bright3=c9d364 # bright yellow

--- a/colors/base16-tango.ini
+++ b/colors/base16-tango.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tango 
+# tinted-foot
+# Scheme name: Tango
 # Scheme author: @Schnouki, based on the Tango Desktop Project
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d3d7cf
 background=2e3436
@@ -16,7 +14,7 @@ regular4=3465a4 # blue
 regular5=75507b # magenta
 regular6=06989a # cyan
 regular7=d3d7cf # white
-bright0=555753 # bright black
+bright0=fce94f # bright black
 bright1=cc0000 # bright red
 bright2=4e9a06 # bright green
 bright3=c4a000 # bright yellow

--- a/colors/base16-tarot.ini
+++ b/colors/base16-tarot.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: tarot 
+# tinted-foot
+# Scheme name: tarot
 # Scheme author: ed (https://codeberg.org/ed)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=aa556f
 background=0e091d
@@ -16,7 +14,7 @@ regular4=6e6080 # blue
 regular5=a45782 # magenta
 regular6=8c9785 # cyan
 regular7=aa556f # white
-bright0=74316b # bright black
+bright0=4b2054 # bright black
 bright1=c53253 # bright red
 bright2=a68e5a # bright green
 bright3=ff6565 # bright yellow

--- a/colors/base16-tender.ini
+++ b/colors/base16-tender.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: tender 
+# tinted-foot
+# Scheme name: tender
 # Scheme author: Jacobo Tabernero (https://github/com/jacoborus/tender.vim)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=eeeeee
 background=282828
@@ -16,7 +14,7 @@ regular4=b3deef # blue
 regular5=d3b987 # magenta
 regular6=73cef4 # cyan
 regular7=eeeeee # white
-bright0=4c4c4c # bright black
+bright0=484848 # bright black
 bright1=f43753 # bright red
 bright2=c9d05c # bright green
 bright3=ffc24b # bright yellow

--- a/colors/base16-terracotta-dark.ini
+++ b/colors/base16-terracotta-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Terracotta Dark 
+# tinted-foot
+# Scheme name: Terracotta Dark
 # Scheme author: Alexander Rossell Hayes (https://github.com/rossellhayes)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b8a59d
 background=241d1a
@@ -16,7 +14,7 @@ regular4=b0a4c3 # blue
 regular5=d8a2b0 # magenta
 regular6=c0bcdb # cyan
 regular7=b8a59d # white
-bright0=594740 # bright black
+bright0=473933 # bright black
 bright1=f6998f # bright red
 bright2=b6c68a # bright green
 bright3=ffc37a # bright yellow

--- a/colors/base16-terracotta.ini
+++ b/colors/base16-terracotta.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Terracotta 
+# tinted-foot
+# Scheme name: Terracotta
 # Scheme author: Alexander Rossell Hayes (https://github.com/rossellhayes)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=473731
 background=efeae8
@@ -16,7 +14,7 @@ regular4=625574 # blue
 regular5=8d5968 # magenta
 regular6=847f9e # cyan
 regular7=473731 # white
-bright0=c0aca4 # bright black
+bright0=d0c1bb # bright black
 bright1=a75045 # bright red
 bright2=7a894a # bright green
 bright3=ce943e # bright yellow

--- a/colors/base16-tokyo-city-dark.ini
+++ b/colors/base16-tokyo-city-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo City Dark 
+# tinted-foot
+# Scheme name: Tokyo City Dark
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d8e2ec
 background=171d23
@@ -16,7 +14,7 @@ regular4=7aa2f7 # blue
 regular5=bb9af7 # magenta
 regular6=89ddff # cyan
 regular7=d8e2ec # white
-bright0=526270 # bright black
+bright0=28323a # bright black
 bright1=f7768e # bright red
 bright2=9ece6a # bright green
 bright3=b7c5d3 # bright yellow

--- a/colors/base16-tokyo-city-light.ini
+++ b/colors/base16-tokyo-city-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo City Light 
+# tinted-foot
+# Scheme name: Tokyo City Light
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=343b59
 background=fbfbfd
@@ -16,7 +14,7 @@ regular4=34548a # blue
 regular5=5a4a78 # magenta
 regular6=4c505e # cyan
 regular7=343b59 # white
-bright0=9699a3 # bright black
+bright0=edeff6 # bright black
 bright1=8c4351 # bright red
 bright2=485e30 # bright green
 bright3=4c505e # bright yellow

--- a/colors/base16-tokyo-city-terminal-dark.ini
+++ b/colors/base16-tokyo-city-terminal-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo City Terminal Dark 
+# tinted-foot
+# Scheme name: Tokyo City Terminal Dark
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d8e2ec
 background=171d23
@@ -16,7 +14,7 @@ regular4=539afc # blue
 regular5=b62d65 # magenta
 regular6=70e1e8 # cyan
 regular7=d8e2ec # white
-bright0=526270 # bright black
+bright0=28323a # bright black
 bright1=d95468 # bright red
 bright2=8bd49c # bright green
 bright3=ebbf83 # bright yellow

--- a/colors/base16-tokyo-city-terminal-light.ini
+++ b/colors/base16-tokyo-city-terminal-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo City Terminal Light 
+# tinted-foot
+# Scheme name: Tokyo City Terminal Light
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=28323a
 background=fbfbfd
@@ -16,7 +14,7 @@ regular4=34548a # blue
 regular5=5a4a78 # magenta
 regular6=0f4b6e # cyan
 regular7=28323a # white
-bright0=b7c5d3 # bright black
+bright0=d8e2ec # bright black
 bright1=8c4351 # bright red
 bright2=33635c # bright green
 bright3=8f5e15 # bright yellow

--- a/colors/base16-tokyo-night-dark.ini
+++ b/colors/base16-tokyo-night-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo Night Dark 
+# tinted-foot
+# Scheme name: Tokyo Night Dark
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a9b1d6
 background=1a1b26
@@ -16,7 +14,7 @@ regular4=2ac3de # blue
 regular5=bb9af7 # magenta
 regular6=b4f9f8 # cyan
 regular7=a9b1d6 # white
-bright0=444b6a # bright black
+bright0=2f3549 # bright black
 bright1=c0caf5 # bright red
 bright2=9ece6a # bright green
 bright3=0db9d7 # bright yellow

--- a/colors/base16-tokyo-night-light.ini
+++ b/colors/base16-tokyo-night-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo Night Light 
+# tinted-foot
+# Scheme name: Tokyo Night Light
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=343b59
 background=d5d6db
@@ -16,7 +14,7 @@ regular4=34548a # blue
 regular5=5a4a78 # magenta
 regular6=3e6968 # cyan
 regular7=343b59 # white
-bright0=9699a3 # bright black
+bright0=dfe0e5 # bright black
 bright1=343b58 # bright red
 bright2=485e30 # bright green
 bright3=166775 # bright yellow

--- a/colors/base16-tokyo-night-moon.ini
+++ b/colors/base16-tokyo-night-moon.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo Night Moon 
+# tinted-foot
+# Scheme name: Tokyo Night Moon
 # Scheme author: Ólafur Bjarki Bogason
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=3b4261
 background=222436
@@ -16,7 +14,7 @@ regular4=82aaff # blue
 regular5=fca7ea # magenta
 regular6=86e1fc # cyan
 regular7=3b4261 # white
-bright0=636da6 # bright black
+bright0=2d3f76 # bright black
 bright1=ff757f # bright red
 bright2=c3e88d # bright green
 bright3=ffc777 # bright yellow

--- a/colors/base16-tokyo-night-storm.ini
+++ b/colors/base16-tokyo-night-storm.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo Night Storm 
+# tinted-foot
+# Scheme name: Tokyo Night Storm
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a9b1d6
 background=24283b
@@ -16,7 +14,7 @@ regular4=2ac3de # blue
 regular5=bb9af7 # magenta
 regular6=b4f9f8 # cyan
 regular7=a9b1d6 # white
-bright0=444b6a # bright black
+bright0=343a52 # bright black
 bright1=c0caf5 # bright red
 bright2=9ece6a # bright green
 bright3=0db9d7 # bright yellow

--- a/colors/base16-tokyo-night-terminal-dark.ini
+++ b/colors/base16-tokyo-night-terminal-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo Night Terminal Dark 
+# tinted-foot
+# Scheme name: Tokyo Night Terminal Dark
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=787c99
 background=16161e
@@ -16,7 +14,7 @@ regular4=7aa2f7 # blue
 regular5=bb9af7 # magenta
 regular6=7dcfff # cyan
 regular7=787c99 # white
-bright0=444b6a # bright black
+bright0=2f3549 # bright black
 bright1=f7768e # bright red
 bright2=41a6b5 # bright green
 bright3=e0af68 # bright yellow

--- a/colors/base16-tokyo-night-terminal-light.ini
+++ b/colors/base16-tokyo-night-terminal-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo Night Terminal Light 
+# tinted-foot
+# Scheme name: Tokyo Night Terminal Light
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=4c505e
 background=d5d6db
@@ -16,7 +14,7 @@ regular4=34548a # blue
 regular5=5a4a78 # magenta
 regular6=0f4b6e # cyan
 regular7=4c505e # white
-bright0=9699a3 # bright black
+bright0=dfe0e5 # bright black
 bright1=8c4351 # bright red
 bright2=33635c # bright green
 bright3=8f5e15 # bright yellow

--- a/colors/base16-tokyo-night-terminal-storm.ini
+++ b/colors/base16-tokyo-night-terminal-storm.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyo Night Terminal Storm 
+# tinted-foot
+# Scheme name: Tokyo Night Terminal Storm
 # Scheme author: Michaël Ball
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=787c99
 background=24283b
@@ -16,7 +14,7 @@ regular4=7aa2f7 # blue
 regular5=bb9af7 # magenta
 regular6=7dcfff # cyan
 regular7=787c99 # white
-bright0=444b6a # bright black
+bright0=343a52 # bright black
 bright1=f7768e # bright red
 bright2=41a6b5 # bright green
 bright3=e0af68 # bright yellow

--- a/colors/base16-tokyodark-terminal.ini
+++ b/colors/base16-tokyodark-terminal.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyodark Terminal 
+# tinted-foot
+# Scheme name: Tokyodark Terminal
 # Scheme author: Tiagovla (https://github.com/tiagovla/)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a0a8cd
 background=11121d
@@ -16,7 +14,7 @@ regular4=7199ee # blue
 regular5=a485dd # magenta
 regular6=38a89d # cyan
 regular7=a0a8cd # white
-bright0=282c34 # bright black
+bright0=212234 # bright black
 bright1=ee6d85 # bright red
 bright2=95c561 # bright green
 bright3=d7a65f # bright yellow

--- a/colors/base16-tokyodark.ini
+++ b/colors/base16-tokyodark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tokyodark 
+# tinted-foot
+# Scheme name: Tokyodark
 # Scheme author: Jamy Golden (https://github.com/JamyGolden), Based on Tokyodark.nvim (https://github.com/tiagovla/tokyodark.nvim)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a0a8cd
 background=11121d
@@ -16,7 +14,7 @@ regular4=7199ee # blue
 regular5=a485dd # magenta
 regular6=9fbbf3 # cyan
 regular7=a0a8cd # white
-bright0=353945 # bright black
+bright0=212234 # bright black
 bright1=ee6d85 # bright red
 bright2=95c561 # bright green
 bright3=d7a65f # bright yellow

--- a/colors/base16-tomorrow-night-eighties.ini
+++ b/colors/base16-tomorrow-night-eighties.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tomorrow Night Eighties 
+# tinted-foot
+# Scheme name: Tomorrow Night Eighties
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cccccc
 background=2d2d2d
@@ -16,7 +14,7 @@ regular4=6699cc # blue
 regular5=cc99cc # magenta
 regular6=66cccc # cyan
 regular7=cccccc # white
-bright0=999999 # bright black
+bright0=515151 # bright black
 bright1=f2777a # bright red
 bright2=99cc99 # bright green
 bright3=ffcc66 # bright yellow

--- a/colors/base16-tomorrow-night.ini
+++ b/colors/base16-tomorrow-night.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tomorrow Night 
+# tinted-foot
+# Scheme name: Tomorrow Night
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c5c8c6
 background=1d1f21
@@ -16,7 +14,7 @@ regular4=81a2be # blue
 regular5=b294bb # magenta
 regular6=8abeb7 # cyan
 regular7=c5c8c6 # white
-bright0=969896 # bright black
+bright0=373b41 # bright black
 bright1=cc6666 # bright red
 bright2=b5bd68 # bright green
 bright3=f0c674 # bright yellow

--- a/colors/base16-tomorrow.ini
+++ b/colors/base16-tomorrow.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Tomorrow 
+# tinted-foot
+# Scheme name: Tomorrow
 # Scheme author: Chris Kempson (http://chriskempson.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=4d4d4c
 background=ffffff
@@ -16,7 +14,7 @@ regular4=4271ae # blue
 regular5=8959a8 # magenta
 regular6=3e999f # cyan
 regular7=4d4d4c # white
-bright0=8e908c # bright black
+bright0=d6d6d6 # bright black
 bright1=c82829 # bright red
 bright2=718c00 # bright green
 bright3=eab700 # bright yellow

--- a/colors/base16-tube.ini
+++ b/colors/base16-tube.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: London Tube 
+# tinted-foot
+# Scheme name: London Tube
 # Scheme author: Jan T. Sott
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=d9d8d8
 background=231f20
@@ -16,7 +14,7 @@ regular4=009ddc # blue
 regular5=98005d # magenta
 regular6=85cebc # cyan
 regular7=d9d8d8 # white
-bright0=737171 # bright black
+bright0=5a5758 # bright black
 bright1=ee2e24 # bright red
 bright2=00853e # bright green
 bright3=ffd204 # bright yellow

--- a/colors/base16-twilight.ini
+++ b/colors/base16-twilight.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Twilight 
+# tinted-foot
+# Scheme name: Twilight
 # Scheme author: David Hart (https://github.com/hartbit)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a7a7a7
 background=1e1e1e
@@ -16,7 +14,7 @@ regular4=7587a6 # blue
 regular5=9b859d # magenta
 regular6=afc4db # cyan
 regular7=a7a7a7 # white
-bright0=5f5a60 # bright black
+bright0=464b50 # bright black
 bright1=cf6a4c # bright red
 bright2=8f9d6a # bright green
 bright3=f9ee98 # bright yellow

--- a/colors/base16-unikitty-dark.ini
+++ b/colors/base16-unikitty-dark.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Unikitty Dark 
+# tinted-foot
+# Scheme name: Unikitty Dark
 # Scheme author: Josh W Lewis (@joshwlewis)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=bcbabe
 background=2e2a31
@@ -16,7 +14,7 @@ regular4=796af5 # blue
 regular5=bb60ea # magenta
 regular6=149bda # cyan
 regular7=bcbabe # white
-bright0=838085 # bright black
+bright0=666369 # bright black
 bright1=d8137f # bright red
 bright2=17ad98 # bright green
 bright3=dc8a0e # bright yellow

--- a/colors/base16-unikitty-light.ini
+++ b/colors/base16-unikitty-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Unikitty Light 
+# tinted-foot
+# Scheme name: Unikitty Light
 # Scheme author: Josh W Lewis (@joshwlewis)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=6c696e
 background=ffffff
@@ -16,7 +14,7 @@ regular4=775dff # blue
 regular5=aa17e6 # magenta
 regular6=149bda # cyan
 regular7=6c696e # white
-bright0=a7a5a8 # bright black
+bright0=c4c3c5 # bright black
 bright1=d8137f # bright red
 bright2=17ad98 # bright green
 bright3=dc8a0e # bright yellow

--- a/colors/base16-unikitty-reversible.ini
+++ b/colors/base16-unikitty-reversible.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Unikitty Reversible 
+# tinted-foot
+# Scheme name: Unikitty Reversible
 # Scheme author: Josh W Lewis (@joshwlewis)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c3c2c4
 background=2e2a31
@@ -16,7 +14,7 @@ regular4=7864fa # blue
 regular5=b33ce8 # magenta
 regular6=149bda # cyan
 regular7=c3c2c4 # white
-bright0=878589 # bright black
+bright0=69666b # bright black
 bright1=d8137f # bright red
 bright2=17ad98 # bright green
 bright3=dc8a0e # bright yellow

--- a/colors/base16-uwunicorn.ini
+++ b/colors/base16-uwunicorn.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: UwUnicorn 
+# tinted-foot
+# Scheme name: UwUnicorn
 # Scheme author: Fernando Marques (https://github.com/RakkiUwU) and Gabriel Fontes (https://github.com/Misterio77)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=eed5d9
 background=241b26
@@ -16,7 +14,7 @@ regular4=6a9eb5 # blue
 regular5=78a38f # magenta
 regular6=9c5fce # cyan
 regular7=eed5d9 # white
-bright0=6c3cb2 # bright black
+bright0=46354a # bright black
 bright1=877bb6 # bright red
 bright2=c965bf # bright green
 bright3=a84a73 # bright yellow

--- a/colors/base16-vesper.ini
+++ b/colors/base16-vesper.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Vesper 
+# tinted-foot
+# Scheme name: Vesper
 # Scheme author: FormalSnake (https://github.com/formalsnake)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b7b7b7
 background=101010
@@ -16,7 +14,7 @@ regular4=8eaaaa # blue
 regular5=d69094 # magenta
 regular6=60a592 # cyan
 regular7=b7b7b7 # white
-bright0=333333 # bright black
+bright0=222222 # bright black
 bright1=de6e6e # bright red
 bright2=5f8787 # bright green
 bright3=ffc799 # bright yellow

--- a/colors/base16-vice.ini
+++ b/colors/base16-vice.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: vice 
+# tinted-foot
+# Scheme name: vice
 # Scheme author: Thomas Leon Highbaugh thighbaugh@zoho.com
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=8b9cbe
 background=17191e
@@ -16,7 +14,7 @@ regular4=00eaff # blue
 regular5=00f6d9 # magenta
 regular6=8265ff # cyan
 regular7=8b9cbe # white
-bright0=383a47 # bright black
+bright0=3c3f4c # bright black
 bright1=ff29a8 # bright red
 bright2=0badff # bright green
 bright3=f0ffaa # bright yellow

--- a/colors/base16-vulcan.ini
+++ b/colors/base16-vulcan.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: vulcan 
+# tinted-foot
+# Scheme name: vulcan
 # Scheme author: Andrey Varfolomeev
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=5b778c
 background=041523
@@ -16,7 +14,7 @@ regular4=977d7c # blue
 regular5=9198a3 # magenta
 regular6=977d7c # cyan
 regular7=5b778c # white
-bright0=7a5759 # bright black
+bright0=003552 # bright black
 bright1=818591 # bright red
 bright2=977d7c # bright green
 bright3=adb4b9 # bright yellow

--- a/colors/base16-windows-10-light.ini
+++ b/colors/base16-windows-10-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Windows 10 Light 
+# tinted-foot
+# Scheme name: Windows 10 Light
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=767676
 background=f2f2f2
@@ -16,7 +14,7 @@ regular4=0037da # blue
 regular5=881798 # magenta
 regular6=3a96dd # cyan
 regular7=767676 # white
-bright0=cccccc # bright black
+bright0=d9d9d9 # bright black
 bright1=c50f1f # bright red
 bright2=13a10e # bright green
 bright3=c19c00 # bright yellow

--- a/colors/base16-windows-10.ini
+++ b/colors/base16-windows-10.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Windows 10 
+# tinted-foot
+# Scheme name: Windows 10
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cccccc
 background=0c0c0c
@@ -16,7 +14,7 @@ regular4=3b78ff # blue
 regular5=b4009e # magenta
 regular6=61d6d6 # cyan
 regular7=cccccc # white
-bright0=767676 # bright black
+bright0=535353 # bright black
 bright1=e74856 # bright red
 bright2=16c60c # bright green
 bright3=f9f1a5 # bright yellow

--- a/colors/base16-windows-95-light.ini
+++ b/colors/base16-windows-95-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Windows 95 Light 
+# tinted-foot
+# Scheme name: Windows 95 Light
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=545454
 background=fcfcfc
@@ -16,7 +14,7 @@ regular4=0000a8 # blue
 regular5=a800a8 # magenta
 regular6=00a8a8 # cyan
 regular7=545454 # white
-bright0=a8a8a8 # bright black
+bright0=c4c4c4 # bright black
 bright1=a80000 # bright red
 bright2=00a800 # bright green
 bright3=a85400 # bright yellow

--- a/colors/base16-windows-95.ini
+++ b/colors/base16-windows-95.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Windows 95 
+# tinted-foot
+# Scheme name: Windows 95
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=a8a8a8
 background=000000
@@ -16,7 +14,7 @@ regular4=5454fc # blue
 regular5=fc54fc # magenta
 regular6=54fcfc # cyan
 regular7=a8a8a8 # white
-bright0=545454 # bright black
+bright0=383838 # bright black
 bright1=fc5454 # bright red
 bright2=54fc54 # bright green
 bright3=fcfc54 # bright yellow

--- a/colors/base16-windows-highcontrast-light.ini
+++ b/colors/base16-windows-highcontrast-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Windows High Contrast Light 
+# tinted-foot
+# Scheme name: Windows High Contrast Light
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=545454
 background=fcfcfc
@@ -16,7 +14,7 @@ regular4=000080 # blue
 regular5=800080 # magenta
 regular6=008080 # cyan
 regular7=545454 # white
-bright0=c0c0c0 # bright black
+bright0=d4d4d4 # bright black
 bright1=800000 # bright red
 bright2=008000 # bright green
 bright3=808000 # bright yellow

--- a/colors/base16-windows-highcontrast.ini
+++ b/colors/base16-windows-highcontrast.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Windows High Contrast 
+# tinted-foot
+# Scheme name: Windows High Contrast
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c0c0c0
 background=000000
@@ -16,7 +14,7 @@ regular4=5454fc # blue
 regular5=fc54fc # magenta
 regular6=54fcfc # cyan
 regular7=c0c0c0 # white
-bright0=545454 # bright black
+bright0=383838 # bright black
 bright1=fc5454 # bright red
 bright2=54fc54 # bright green
 bright3=fcfc54 # bright yellow

--- a/colors/base16-windows-nt-light.ini
+++ b/colors/base16-windows-nt-light.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Windows NT Light 
+# tinted-foot
+# Scheme name: Windows NT Light
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=808080
 background=ffffff
@@ -16,7 +14,7 @@ regular4=000080 # blue
 regular5=800080 # magenta
 regular6=008080 # cyan
 regular7=808080 # white
-bright0=c0c0c0 # bright black
+bright0=d5d5d5 # bright black
 bright1=800000 # bright red
 bright2=008000 # bright green
 bright3=808000 # bright yellow

--- a/colors/base16-windows-nt.ini
+++ b/colors/base16-windows-nt.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Windows NT 
+# tinted-foot
+# Scheme name: Windows NT
 # Scheme author: Fergus Collins (https://github.com/C-Fergus)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=c0c0c0
 background=000000
@@ -16,7 +14,7 @@ regular4=0000ff # blue
 regular5=ff00ff # magenta
 regular6=00ffff # cyan
 regular7=c0c0c0 # white
-bright0=808080 # bright black
+bright0=555555 # bright black
 bright1=ff0000 # bright red
 bright2=00ff00 # bright green
 bright3=ffff00 # bright yellow

--- a/colors/base16-woodland.ini
+++ b/colors/base16-woodland.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Woodland 
+# tinted-foot
+# Scheme name: Woodland
 # Scheme author: Jay Cornwall (https://jcornwall.com)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=cabcb1
 background=231e18
@@ -16,7 +14,7 @@ regular4=88a4d3 # blue
 regular5=bb90e2 # magenta
 regular6=6eb958 # cyan
 regular7=cabcb1 # white
-bright0=9d8b70 # bright black
+bright0=48413a # bright black
 bright1=d35c5c # bright red
 bright2=b7ba53 # bright green
 bright3=e0ac16 # bright yellow

--- a/colors/base16-xcode-dusk.ini
+++ b/colors/base16-xcode-dusk.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: XCode Dusk 
+# tinted-foot
+# Scheme name: XCode Dusk
 # Scheme author: Elsa Gonsiorowski (https://github.com/gonsie)
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=939599
 background=282b35
@@ -16,7 +14,7 @@ regular4=790ead # blue
 regular5=b21889 # magenta
 regular6=00a0be # cyan
 regular7=939599 # white
-bright0=686a71 # bright black
+bright0=53555d # bright black
 bright1=b21889 # bright red
 bright2=df0002 # bright green
 bright3=438288 # bright yellow

--- a/colors/base16-zenbones.ini
+++ b/colors/base16-zenbones.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Zenbones 
+# tinted-foot
+# Scheme name: Zenbones
 # Scheme author: mcchrish
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=b279a7
 background=191919
@@ -16,7 +14,7 @@ regular4=cf86c1 # blue
 regular5=65b8c1 # magenta
 regular6=61abda # cyan
 regular7=b279a7 # white
-bright0=b77e64 # bright black
+bright0=819b69 # bright black
 bright1=3d3839 # bright red
 bright2=d68c67 # bright green
 bright3=8bae68 # bright yellow

--- a/colors/base16-zenburn.ini
+++ b/colors/base16-zenburn.ini
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: Zenburn 
+# tinted-foot
+# Scheme name: Zenburn
 # Scheme author: elnawe
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground=dcdccc
 background=383838
@@ -16,7 +14,7 @@ regular4=7cb8bb # blue
 regular5=dc8cc3 # magenta
 regular6=93e0e3 # cyan
 regular7=dcdccc # white
-bright0=6f6f6f # bright black
+bright0=606060 # bright black
 bright1=dca3a3 # bright red
 bright2=5f7f5f # bright green
 bright3=e0cf9f # bright yellow

--- a/colors/base24-brogrammer.ini
+++ b/colors/base24-brogrammer.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: Brogrammer
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=c1c8d7
+background=131313
+regular0=131313 # black
+regular1=f71118 # red
+regular2=2cc55d # green
+regular3=0f80d5 # yellow
+regular4=2a84d2 # blue
+regular5=4e59b7 # magenta
+regular6=0f80d5 # cyan
+regular7=c1c8d7 # white
+bright0=2a3141 # bright black
+bright1=de342e # bright red
+bright2=1dd260 # bright green
+bright3=f2bd09 # bright yellow
+bright4=509bdc # bright blue
+bright5=524fb9 # bright magenta
+bright6=289af0 # bright cyan
+bright7=ffffff # bright white
+16=ecb90f
+17=7b080c
+18=1f1f1f
+19=2a3141
+20=d6dae4
+21=e3e6ed

--- a/colors/base24-chalk.ini
+++ b/colors/base24-chalk.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: Chalk
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=d0d0d0
+background=151515
+regular0=151515 # black
+regular1=fa859c # red
+regular2=a1bb54 # green
+regular3=ddb26f # yellow
+regular4=5ab9ed # blue
+regular5=db8fea # magenta
+regular6=10bcad # cyan
+regular7=d0d0d0 # white
+bright0=303030 # bright black
+bright1=fb9fb1 # bright red
+bright2=acc267 # bright green
+bright3=eda987 # bright yellow
+bright4=6fc2ef # bright blue
+bright5=e1a3ee # bright magenta
+bright6=12cfc0 # bright cyan
+bright7=f5f5f5 # bright white
+16=ea9971
+17=deaf8f
+18=202020
+19=303030
+20=b0b0b0
+21=e0e0e0

--- a/colors/base24-dracula.ini
+++ b/colors/base24-dracula.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: Dracula
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=f8f8f2
+background=282a36
+regular0=282a36 # black
+regular1=ff5555 # red
+regular2=50fa7b # green
+regular3=f1fa8c # yellow
+regular4=80bfff # blue
+regular5=ff79c6 # magenta
+regular6=8be9fd # cyan
+regular7=f8f8f2 # white
+bright0=44475a # bright black
+bright1=f28c8c # bright red
+bright2=a3f5b8 # bright green
+bright3=eef5a3 # bright yellow
+bright4=a3ccf5 # bright blue
+bright5=f5a3d2 # bright magenta
+bright6=baedf7 # bright cyan
+bright7=ffffff # bright white
+16=ffb86c
+17=bd93f9
+18=363447
+19=44475a
+20=9ea8c7
+21=f0f1f4

--- a/colors/base24-espresso.ini
+++ b/colors/base24-espresso.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: Espresso
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=c7c7c5
+background=262626
+regular0=262626 # black
+regular1=d25151 # red
+regular2=a5c261 # green
+regular3=8ab7d9 # yellow
+regular4=6c99bb # blue
+regular5=d197d9 # magenta
+regular6=bed6ff # cyan
+regular7=c7c7c5 # white
+bright0=535353 # bright black
+bright1=f00c0c # bright red
+bright2=c2e075 # bright green
+bright3=e1e38b # bright yellow
+bright4=8ab7d9 # bright blue
+bright5=efb5f7 # bright magenta
+bright6=dcf3ff # bright cyan
+bright7=ffffff # bright white
+16=ffc66d
+17=692828
+18=343434
+19=535353
+20=a0a09f
+21=eeeeec

--- a/colors/base24-flat.ini
+++ b/colors/base24-flat.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: Flat
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=8c939a
+background=082845
+regular0=082845 # black
+regular1=a82320 # red
+regular2=2d9440 # green
+regular3=3c7dd2 # yellow
+regular4=3167ac # blue
+regular5=781aa0 # magenta
+regular6=2c9370 # cyan
+regular7=8c939a # white
+bright0=2e2e45 # bright black
+bright1=d4312e # bright red
+bright2=32a548 # bright green
+bright3=e5be0c # bright yellow
+bright4=3c7dd2 # bright blue
+bright5=8230a7 # bright magenta
+bright6=35b387 # bright cyan
+bright7=e7eced # bright white
+16=e58d11
+17=541110
+18=1d2845
+19=2e2e45
+20=68717b
+21=b0b6ba

--- a/colors/base24-framer.ini
+++ b/colors/base24-framer.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: Framer
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=a9a9a9
+background=111111
+regular0=111111 # black
+regular1=ff5555 # red
+regular2=98ec65 # green
+regular3=33bbff # yellow
+regular4=00aaff # blue
+regular5=aa88ff # magenta
+regular6=88ddff # cyan
+regular7=a9a9a9 # white
+bright0=414141 # bright black
+bright1=ff8888 # bright red
+bright2=b6f292 # bright green
+bright3=ffd966 # bright yellow
+bright4=33bbff # bright blue
+bright5=cebbff # bright magenta
+bright6=bbecff # bright cyan
+bright7=ffffff # bright white
+16=ffcc33
+17=7f2a2a
+18=141414
+19=414141
+20=868686
+21=cccccc

--- a/colors/base24-github.ini
+++ b/colors/base24-github.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: Github
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=d8d8d8
+background=f4f4f4
+regular0=f4f4f4 # black
+regular1=970b16 # red
+regular2=07962a # green
+regular3=2e6cba # yellow
+regular4=003e8a # blue
+regular5=e94691 # magenta
+regular6=89d1ec # cyan
+regular7=d8d8d8 # white
+bright0=666666 # bright black
+bright1=de0000 # bright red
+bright2=87d5a2 # bright green
+bright3=f1d007 # bright yellow
+bright4=2e6cba # bright blue
+bright5=ffa29f # bright magenta
+bright6=1cfafe # bright cyan
+bright7=ffffff # bright white
+16=f8eec7
+17=4b050b
+18=3e3e3e
+19=666666
+20=b2b2b2
+21=ffffff

--- a/colors/base24-hardcore.ini
+++ b/colors/base24-hardcore.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: Hardcore
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=a9a9a9
+background=111111
+regular0=111111 # black
+regular1=ff5555 # red
+regular2=98ec65 # green
+regular3=33bbff # yellow
+regular4=00aaff # blue
+regular5=aa88ff # magenta
+regular6=88ddff # cyan
+regular7=a9a9a9 # white
+bright0=414141 # bright black
+bright1=ff8888 # bright red
+bright2=b6f292 # bright green
+bright3=ffd966 # bright yellow
+bright4=33bbff # bright blue
+bright5=cebbff # bright magenta
+bright6=bbecff # bright cyan
+bright7=ffffff # bright white
+16=ffcc33
+17=7f2a2a
+18=141414
+19=414141
+20=868686
+21=cccccc

--- a/colors/base24-one-black.ini
+++ b/colors/base24-one-black.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: One Black
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=abb2bf
+background=000000
+regular0=000000 # black
+regular1=e05561 # red
+regular2=8cc265 # green
+regular3=e6b965 # yellow
+regular4=4aa5f0 # blue
+regular5=c162de # magenta
+regular6=42b3c2 # cyan
+regular7=abb2bf # white
+bright0=4f5666 # bright black
+bright1=ff616e # bright red
+bright2=a5e075 # bright green
+bright3=f0a45d # bright yellow
+bright4=4dc4ff # bright blue
+bright5=de73ff # bright magenta
+bright6=4cd1e0 # bright cyan
+bright7=ffffff # bright white
+16=d18f52
+17=bf4034
+18=000000
+19=4f5666
+20=9196a1
+21=e6e6e6

--- a/colors/base24-one-dark.ini
+++ b/colors/base24-one-dark.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: One Dark
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=abb2bf
+background=282c34
+regular0=282c34 # black
+regular1=e05561 # red
+regular2=8cc265 # green
+regular3=e6b965 # yellow
+regular4=4aa5f0 # blue
+regular5=c162de # magenta
+regular6=42b3c2 # cyan
+regular7=abb2bf # white
+bright0=4f5666 # bright black
+bright1=ff616e # bright red
+bright2=a5e075 # bright green
+bright3=f0a45d # bright yellow
+bright4=4dc4ff # bright blue
+bright5=de73ff # bright magenta
+bright6=4cd1e0 # bright cyan
+bright7=ffffff # bright white
+16=d18f52
+17=bf4034
+18=3f4451
+19=4f5666
+20=9196a1
+21=e6e6e6

--- a/colors/base24-one-light.ini
+++ b/colors/base24-one-light.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: One Light
+# Scheme author: FredHappyface (https://github.com/fredHappyface)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=383a42
+background=e7e7e9
+regular0=e7e7e9 # black
+regular1=ca1243 # red
+regular2=50a14f # green
+regular3=febb2a # yellow
+regular4=4078f2 # blue
+regular5=a626a4 # magenta
+regular6=0184bc # cyan
+regular7=383a42 # white
+bright0=cacace # bright black
+bright1=ec2258 # bright red
+bright2=6db76c # bright green
+bright3=f4a701 # bright yellow
+bright4=709af5 # bright blue
+bright5=d02fcd # bright magenta
+bright6=01a7ef # bright cyan
+bright7=090a0b # bright white
+16=c18401
+17=986801
+18=dfdfe1
+19=cacace
+20=696c77
+21=202227

--- a/colors/base24-sparky.ini
+++ b/colors/base24-sparky.ini
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: Sparky
+# Scheme author: Leila Sother (https://github.com/mixcoac)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground=f4f5f0
+background=072b31
+regular0=072b31 # black
+regular1=ff585d # red
+regular2=78d64b # green
+regular3=fbdd40 # yellow
+regular4=4698cb # blue
+regular5=d59ed7 # magenta
+regular6=2dccd3 # cyan
+regular7=f4f5f0 # white
+bright0=003c46 # bright black
+bright1=ff7276 # bright red
+bright2=8edd65 # bright green
+bright3=f6eb61 # bright yellow
+bright4=69b3e7 # bright blue
+bright5=f99fc9 # bright magenta
+bright6=00c1d5 # bright cyan
+bright7=ffffff # bright white
+16=ff8f1c
+17=9b704d
+18=00313c
+19=003c46
+20=00778b
+21=f5f5f1

--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -1,10 +1,8 @@
-# base16-foot
-# Scheme name: {{scheme-name}} 
+# tinted-foot
+# Scheme name: {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-# include in foot.ini like so:
-# include=~/.config/foot/colours.ini
-# must be included under [main], or untitled section at beginning of file
+
 [colors]
 foreground={{base05-hex}}
 background={{base00-hex}}
@@ -16,7 +14,7 @@ regular4={{base0D-hex}} # blue
 regular5={{base0E-hex}} # magenta
 regular6={{base0C-hex}} # cyan
 regular7={{base05-hex}} # white
-bright0={{base03-hex}} # bright black
+bright0={{base02-hex}} # bright black
 bright1={{base08-hex}} # bright red
 bright2={{base0B-hex}} # bright green
 bright3={{base0A-hex}} # bright yellow

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -1,0 +1,30 @@
+# tinted-foot
+# Scheme name: {{scheme-name}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+[colors]
+foreground={{base05-hex}}
+background={{base00-hex}}
+regular0={{base00-hex}} # black
+regular1={{base08-hex}} # red
+regular2={{base0B-hex}} # green
+regular3={{base0A-hex}} # yellow
+regular4={{base0D-hex}} # blue
+regular5={{base0E-hex}} # magenta
+regular6={{base0C-hex}} # cyan
+regular7={{base05-hex}} # white
+bright0={{base02-hex}} # bright black
+bright1={{base12-hex}} # bright red
+bright2={{base14-hex}} # bright green
+bright3={{base13-hex}} # bright yellow
+bright4={{base16-hex}} # bright blue
+bright5={{base17-hex}} # bright magenta
+bright6={{base15-hex}} # bright cyan
+bright7={{base07-hex}} # bright white
+16={{base09-hex}}
+17={{base0F-hex}}
+18={{base01-hex}}
+19={{base02-hex}}
+20={{base04-hex}}
+21={{base06-hex}}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,3 +1,9 @@
-default:
+base16:
   extension: .ini
   output: colors
+  supported-systems: [base16]
+
+base24:
+  extension: .ini
+  output: colors
+  supported-systems: [base24]


### PR DESCRIPTION
- Add `templates/base24.mustache` template
- Change `bright0` from `base03` to `base02` since ANSI 8 (Bright Black) is defined as `base02` in the [styling spec](https://github.com/tinted-theming/home/blob/main/styling.md)
- Add installation instructions for usage with [Tinty](https://github.com/tinted-theming/tinty)
- As with the other repos, when the repo has more than the base16 scheme system supported, the repo is renamed to `tinted-*`
- Use shared actions to auto assign github issues to maintainers and shared action to auto update themes each week