### PR TITLE
Move to tinted-terminal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tinted-theming/foot
+* @tinted-theming/foot-terminal

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,6 @@
 name: "Update with the latest tinted-theming colorschemes"
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 0" # https://crontab.guru/every-week
 
 jobs:
   build-and-commit:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Tinted Foot
 
+**Deprecated**: tinted-foot and all the other Tinted Theming
+terminal template repositories have moved to a single [Tinted
+Terminal](https://github.com/tinted-theming/tinted-terminal) repository.
+
+---
+
 [Tinted Theming] template for [foot]. Includes both [base16] and
 [base24] themes.
 


### PR DESCRIPTION
As discussed in https://github.com/tinted-theming/home/issues/44#issuecomment-2518520414, this PR adds a deprecation notice and links to [tinted-terminal](https://github.com/tinted-theming/tinted-terminal). @tinted-theming/foot-terminal  should already have maintainer access for [tinted-terminal](https://github.com/tinted-theming/tinted-terminal). Once this is merged I'll archive this repo.

- Add deprecation notice to README
- Remove cron job